### PR TITLE
🛡️ Sentinel: Fix API key leakage in JFrog scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-14 - Leakage of API Keys in Verbose Logs
+**Vulnerability:** Use of `curl -v` with sensitive headers (`X-JFrog-Art-Api: $JFROG_API_KEY`) exposes the API key in the standard error output.
+**Learning:** Verbose output in `curl` includes request headers. If these headers contain secrets, they will be printed to logs, which is a security risk in CI/CD environments or shared systems.
+**Prevention:** Avoid using verbose mode (`-v`, `--verbose`) in production scripts when handling secrets. Use specific `curl` options to debug if needed, or rely on exit codes and structured error messages.

--- a/jfrog_scripts/pull_generic.sh
+++ b/jfrog_scripts/pull_generic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # This script downloads a file from JFrog Artifactory.
 # Usage: ./pull_generic.sh <source_file_path_in_repo> <local_output_filename>
@@ -9,10 +9,19 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
+# Validate environment variables
+for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  if [ -z "${!var:-}" ]; then
+    echo "Error: Environment variable $var is not set."
+    exit 1
+  fi
+done
+
 SOURCE_PATH="$1"
 OUTPUT_FILENAME="$2"
 
-curl -v -H "X-JFrog-Art-Api:$JFROG_API_KEY" \
+# Removed -v to prevent leaking JFROG_API_KEY in logs
+curl -sS -H "X-JFrog-Art-Api: $JFROG_API_KEY" \
      -L -o "$OUTPUT_FILENAME" \
      "$JFROG_URL/$JFROG_REPO/$SOURCE_PATH"
 

--- a/jfrog_scripts/upload_generic.sh
+++ b/jfrog_scripts/upload_generic.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 # This script uploads a file to JFrog Artifactory using the generic upload API.
 # Usage: ./upload_generic.sh <local_file_path> <target_path_in_repo>
@@ -9,10 +9,24 @@ if [ $# -ne 2 ]; then
   exit 1
 fi
 
+# Validate environment variables
+for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  if [ -z "${!var:-}" ]; then
+    echo "Error: Environment variable $var is not set."
+    exit 1
+  fi
+done
+
 LOCAL_FILE="$1"
 TARGET_PATH="$2"
 
-curl -v \
+if [ ! -f "$LOCAL_FILE" ]; then
+  echo "Error: Local file '$LOCAL_FILE' not found."
+  exit 1
+fi
+
+# Removed -v to prevent leaking JFROG_API_KEY in logs
+curl -sS \
   -H "X-JFrog-Art-Api: $JFROG_API_KEY" \
   -H "Content-Type: application/octet-stream" \
   -T "$LOCAL_FILE" \


### PR DESCRIPTION
This PR addresses a security vulnerability where JFrog API keys could be leaked in CI/CD logs due to the use of verbose output in `curl` commands. It also enhances the robustness of the JFrog scripts by adding environment variable validation and stricter error handling.

---
*PR created automatically by Jules for task [17640142600572116299](https://jules.google.com/task/17640142600572116299) started by @kobi070*