### PR TITLE
🛡️ Sentinel: Secure PAT handling in az_devops_config.sh

### DIFF
--- a/az_scripts/az_devops_config.sh
+++ b/az_scripts/az_devops_config.sh
@@ -2,16 +2,17 @@
 
 # Script to configure Azure DevOps CLI with Organization URL and Personal Access Token (PAT).
 # Useful for initializing Azure DevOps CLI in CI/CD environments.
-# Usage: ./az_devops_config.sh <org_url> <pat>
+# Usage: ./az_devops_config.sh <org_url> [pat]
 # Example: ./az_devops_config.sh https://dev.azure.com/my-org/ my-long-pat-token
+# Note: Recommends using AZ_DEVOPS_PAT environment variable for the PAT to avoid exposure.
 
 set -euo pipefail
 
 # Help function
 usage() {
-    echo "Usage: $0 <org_url> <pat>"
+    echo "Usage: $0 <org_url> [pat]"
     echo "  org_url: The Azure DevOps Organization URL"
-    echo "  pat: Personal Access Token with appropriate scopes"
+    echo "  pat: (optional) Personal Access Token. Can also be set via AZ_DEVOPS_PAT env var."
     exit 1
 }
 
@@ -27,12 +28,18 @@ if ! command -v az &> /dev/null; then
 fi
 
 # Input validation
-if [ "$#" -ne 2 ]; then
+if [ "$#" -lt 1 ]; then
     usage
 fi
 
 ORG_URL=$1
-PAT=$2
+# Prefer argument, fallback to environment variable
+PAT=${2:-${AZ_DEVOPS_PAT:-}}
+
+if [ -z "$PAT" ]; then
+    echo "Error: Personal Access Token (PAT) must be provided as the second argument or via AZ_DEVOPS_PAT environment variable."
+    exit 1
+fi
 
 echo "Configuring Azure DevOps CLI..."
 


### PR DESCRIPTION
### 🛡️ Sentinel: [MEDIUM] Secure PAT handling in az_devops_config.sh

**🚨 Severity:** MEDIUM

**💡 Vulnerability:** The Personal Access Token (PAT) was required as a mandatory command-line argument. Command-line arguments are visible in process lists (e.g., `ps aux`), shell history files, and often captured in CI/CD logs, making this an insecure way to handle secrets.

**🎯 Impact:** A PAT could be accidentally exposed to other users on the system or leaked in automation logs, potentially leading to unauthorized access to the Azure DevOps organization.

**🔧 Fix:** 
- Updated `az_scripts/az_devops_config.sh` to check for the `AZ_DEVOPS_PAT` environment variable.
- Made the `pat` command-line argument optional; the script now prefers the argument if provided, otherwise falls back to the environment variable.
- Improved input validation to ensure a PAT is provided via at least one of these methods.
- Updated documentation and usage help to recommend the more secure environment variable approach.

**✅ Verification:**
- Verified the logic using a dedicated test script (`verify_pat_logic.sh`) that simulated argument vs. environment variable precedence.
- Checked for syntax errors using `bash -n az_scripts/az_devops_config.sh`.
- Performed a code review and verified against shell scripting best practices.

---
*PR created automatically by Jules for task [2135535423046314689](https://jules.google.com/task/2135535423046314689) started by @kobi070*