### PR TITLE
🛡️ Sentinel: secure credential handling in jfrog_config.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** Use of `curl -v` with sensitive headers (`X-JFrog-Art-Api: $JFROG_API_KEY`) exposes the API key in the standard error output.
 **Learning:** Verbose output in `curl` includes request headers. If these headers contain secrets, they will be printed to logs, which is a security risk in CI/CD environments or shared systems.
 **Prevention:** Avoid using verbose mode (`-v`, `--verbose`) in production scripts when handling secrets. Use specific `curl` options to debug if needed, or rely on exit codes and structured error messages.
+
+## 2025-05-15 - Secret Exposure in Process Lists via Positional Arguments
+**Vulnerability:** Passing passwords, tokens, or API keys as command-line arguments (e.g., `./script.sh <secret>`) makes them visible to all users on the system via `ps` or `/proc` and often records them in shell history files.
+**Learning:** Many scripts in this repository were initially designed to take secrets as positional arguments for simplicity, creating a significant security gap.
+**Prevention:** Prioritize environment variables for all secrets. If positional arguments must be supported for backward compatibility, implement a security warning and encourage the use of environment variables instead.

--- a/jfrog_scripts/jfrog_config.sh
+++ b/jfrog_scripts/jfrog_config.sh
@@ -2,18 +2,21 @@
 
 # Script to configure the JFrog CLI with server details.
 # Useful for initializing JFrog CLI in CI/CD environments.
-# Usage: ./jfrog_config.sh <server_id> <url> <user> <password_or_token>
+# Usage: ./jfrog_config.sh <server_id> <url> <user> [password_or_token]
 # Example: ./jfrog_config.sh my-artifactory https://artifactory.example.com admin AKCp8hj...
+# Note: Recommends using JFROG_PASSWORD, JFROG_API_KEY, or JFROG_TOKEN environment variables
+# to avoid secret exposure in process lists and shell history.
 
 set -euo pipefail
 
 # Help function
 usage() {
-    echo "Usage: $0 <server_id> <url> <user> <password_or_token>"
+    echo "Usage: $0 <server_id> <url> <user> [password_or_token]"
     echo "  server_id: A unique identifier for this server configuration"
     echo "  url: The JFrog Artifactory URL"
     echo "  user: The username"
-    echo "  password_or_token: The password or API key/token"
+    echo "  password_or_token: (Optional) The password or API key/token. "
+    echo "                     Better to use JFROG_PASSWORD, JFROG_API_KEY, or JFROG_TOKEN env var."
     exit 1
 }
 
@@ -31,14 +34,27 @@ fi
 JF_BIN=$(command -v jf || command -v jfrog)
 
 # Input validation
-if [ "$#" -ne 4 ]; then
+if [ "$#" -lt 3 ]; then
     usage
 fi
 
 SERVER_ID=$1
 URL=$2
 USER=$3
-PASSWORD=$4
+
+# Credential selection: Environment variable prioritized over argument
+PASSWORD=${JFROG_PASSWORD:-${JFROG_API_KEY:-${JFROG_TOKEN:-${4:-}}}}
+
+if [ -z "$PASSWORD" ]; then
+    echo "Error: Password, API key, or token must be provided via environment variable"
+    echo "(JFROG_PASSWORD, JFROG_API_KEY, or JFROG_TOKEN) or as the 4th argument."
+    exit 1
+fi
+
+if [ -z "${JFROG_PASSWORD:-}${JFROG_API_KEY:-}${JFROG_TOKEN:-}" ] && [ -n "${4:-}" ]; then
+    echo "WARNING: Passing secrets as command-line arguments is insecure."
+    echo "Consider using JFROG_PASSWORD, JFROG_API_KEY, or JFROG_TOKEN environment variables."
+fi
 
 echo "Configuring JFrog CLI for server: $SERVER_ID..."
 


### PR DESCRIPTION
### 🛡️ Sentinel Security Improvement

**Severity:** MEDIUM
**Vulnerability:** Secrets (passwords/tokens) passed as command-line arguments are exposed in process lists (e.g., `ps aux`) and shell history files.
**Impact:** Local users or systems with access to process metadata or shell logs could discover JFrog Artifactory credentials.
**Fix:** Modified `jfrog_scripts/jfrog_config.sh` to prioritize the use of environment variables (`JFROG_PASSWORD`, `JFROG_API_KEY`, or `JFROG_TOKEN`).
**Verification:** 
- Created a test script with a mock `jf` binary.
- Verified that environment variables are correctly prioritized.
- Verified that a security warning is issued when the positional argument is used.
- Verified that the script exits gracefully when no credentials are provided.

---
*PR created automatically by Jules for task [3901255052304534082](https://jules.google.com/task/3901255052304534082) started by @kobi070*