### PR TITLE
🛡️ Sentinel: Secure Git authentication in Azure DevOps scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** Passing passwords, tokens, or API keys as command-line arguments (e.g., `./script.sh <secret>`) makes them visible to all users on the system via `ps` or `/proc` and often records them in shell history files.
 **Learning:** Many scripts in this repository were initially designed to take secrets as positional arguments for simplicity, creating a significant security gap.
 **Prevention:** Prioritize environment variables for all secrets. If positional arguments must be supported for backward compatibility, implement a security warning and encourage the use of environment variables instead.
+
+## 2025-05-16 - PAT Exposure in Git Configuration via URLs
+**Vulnerability:** Embedding Personal Access Tokens (PAT) directly in Git remote URLs (e.g., `https://<pat>@dev.azure.com/...`) causes Git to store the token in plaintext within the `.git/config` file.
+**Learning:** This exposure persists even after the script finishes, as the remote URL is a persistent part of the repository configuration. Anyone with access to the local repository folder can retrieve the PAT.
+**Prevention:** Use `git -c http.extraheader="Authorization: Basic <base64-pat>"` for Git operations to provide authentication for a single command without storing it in the repository configuration. Always prefer environment variables for passing the PAT to the script.

--- a/az_scripts/az_script_advance.sh
+++ b/az_scripts/az_script_advance.sh
@@ -6,10 +6,18 @@ read -p "Enter the name for the repository: " repo_name
 read -p "Enter the name for the pipeline: " pipeline_name
 read -p "Enter the name of the resource group: " resource_group
 
-org_url=""
-project_name=""
-location=""
-pat=""
+org_url="${AZ_DEVOPS_ORG_URL:-}"
+project_name="${AZ_DEVOPS_PROJECT:-}"
+location="${AZ_LOCATION:-eastus}"
+pat="${AZ_DEVOPS_PAT:-}"
+
+# Input validation for essential variables
+if [[ -z "$org_url" ]]; then
+    read -p "Enter Azure DevOps Organization URL: " org_url
+fi
+if [[ -z "$project_name" ]]; then
+    read -p "Enter Azure DevOps Project Name: " project_name
+fi
 
 # Check if an Azure subscription is already set
 current_subscription=$(az account show --query "id" --output tsv 2>/dev/null)
@@ -22,7 +30,17 @@ else
 fi
 
 # Extract organization name from URL
-org_name=$(echo "$org_url" | sed 's|https://dev.azure.com/||')
+org_name=$(echo "$org_url" | sed 's|https://dev.azure.com/||' | sed 's|/.*||')
+
+# Ensure PAT is available
+if [[ -z "$pat" ]]; then
+    read -s -p "Enter Azure DevOps PAT: " pat
+    echo ""
+fi
+
+# Prepare Base64 encoded PAT for Git authentication
+# Azure DevOps uses an empty username with the PAT as the password
+B64_PAT=$(echo -n ":$pat" | base64)
 
 # Configure Azure and Azure DevOps CLI
 echo "Configuring Azure CLI and DevOps extension..."
@@ -41,8 +59,8 @@ cd "$temp_dir"
 
 if [[ "$repo_exists" == "$repo_name" ]]; then
     echo "Repository $repo_name already exists, cloning it into temp directory."
-    # Clone the existing repository into the temp directory
-    git clone "https://${pat}@dev.azure.com/${org_name}/${project_name}/_git/${repo_name}"
+    # Clone the existing repository into the temp directory securely
+    git -c http.extraheader="Authorization: Basic $B64_PAT" clone "https://dev.azure.com/${org_name}/${project_name}/_git/${repo_name}"
     cd "$repo_name"
 else
     echo "Creating repository $repo_name..."
@@ -64,10 +82,10 @@ else
     git add .
     git commit -m "Initial commit with test code and requirements"
 
-    git remote add origin "https://${pat}@dev.azure.com/${org_name}/${project_name}/_git/${repo_name}"
+    git remote add origin "https://dev.azure.com/${org_name}/${project_name}/_git/${repo_name}"
 
     echo "Pushing code to repository..."
-    git push -u origin master
+    git -c http.extraheader="Authorization: Basic $B64_PAT" push -u origin master
 fi
 
 # Check if azure-pipelines.yml already exists
@@ -102,8 +120,8 @@ EOL
     git add azure-pipelines.yml
     git commit -m "Add azure-pipelines.yml for CI pipeline"
 
-    # Push the changes (including the YAML file) to the repository
-    git push
+    # Push the changes (including the YAML file) to the repository securely
+    git -c http.extraheader="Authorization: Basic $B64_PAT" push
 else
     echo "azure-pipelines.yml already exists. Skipping creation."
 fi

--- a/az_scripts/az_script_with_user.sh
+++ b/az_scripts/az_script_with_user.sh
@@ -6,10 +6,18 @@ read -p "Enter the name for the repository: " repo_name
 read -p "Enter the name for the pipeline: " pipeline_name
 read -p "Enter the name of the resource group: " resource_group
 
-org_url=""
-project_name=""
-location=""
-pat=""
+org_url="${AZ_DEVOPS_ORG_URL:-}"
+project_name="${AZ_DEVOPS_PROJECT:-}"
+location="${AZ_LOCATION:-eastus}"
+pat="${AZ_DEVOPS_PAT:-}"
+
+# Input validation for essential variables
+if [[ -z "$org_url" ]]; then
+    read -p "Enter Azure DevOps Organization URL: " org_url
+fi
+if [[ -z "$project_name" ]]; then
+    read -p "Enter Azure DevOps Project Name: " project_name
+fi
 
 # Check if an Azure subscription is already set
 current_subscription=$(az account show --query "id" --output tsv 2>/dev/null)
@@ -22,7 +30,17 @@ else
 fi
 
 # Extract organization name from URL
-org_name=$(echo "$org_url" | sed 's|https://dev.azure.com/||')
+org_name=$(echo "$org_url" | sed 's|https://dev.azure.com/||' | sed 's|/.*||')
+
+# Ensure PAT is available
+if [[ -z "$pat" ]]; then
+    read -s -p "Enter Azure DevOps PAT: " pat
+    echo ""
+fi
+
+# Prepare Base64 encoded PAT for Git authentication
+# Azure DevOps uses an empty username with the PAT as the password
+B64_PAT=$(echo -n ":$pat" | base64)
 
 # Configure Azure and Azure DevOps CLI
 echo "Configuring Azure CLI and DevOps extension..."
@@ -61,10 +79,10 @@ echo "pytest" > requirements.txt
 git add .
 git commit -m "Initial commit with test code and requirements"
 
-git remote add origin "https://${pat}@dev.azure.com/${org_name}/${project_name}/_git/${repo_name}"
+git remote add origin "https://dev.azure.com/${org_name}/${project_name}/_git/${repo_name}"
 
 echo "Pushing code to repository..."
-git push -u origin master
+git -c http.extraheader="Authorization: Basic $B64_PAT" push -u origin master
 
 # Create azure-pipelines.yml file dynamically
 echo "Creating azure-pipelines.yml file..."
@@ -97,8 +115,8 @@ EOL
 git add azure-pipelines.yml
 git commit -m "Add azure-pipelines.yml for CI pipeline"
 
-# Push the changes (including the YAML file) to the repository
-git push
+# Push the changes (including the YAML file) to the repository securely
+git -c http.extraheader="Authorization: Basic $B64_PAT" push
 
 # Step 6: Ensure the pipeline exists
 echo "Checking if pipeline '$pipeline_name' exists..."


### PR DESCRIPTION
This PR addresses a high-priority security vulnerability where Azure DevOps Personal Access Tokens (PAT) were being embedded directly into Git remote URLs. This practice causes the PAT to be stored in plaintext within the `.git/config` file of the repository, posing a significant risk of secret exposure.

### 🔧 Fix:
- Implemented `git -c http.extraheader="Authorization: Basic <base64-pat>"` for all Git operations (`clone`, `push`).
- Transitioned scripts to use a generic remote URL (`https://dev.azure.com/...`) instead of one containing the PAT.
- Added support for environment variables (`AZ_DEVOPS_PAT`, `AZ_DEVOPS_ORG_URL`, `AZ_DEVOPS_PROJECT`) to enable secure automation.
- Implemented `read -s` for manual PAT input to prevent terminal echo.

### ✅ Verification:
- Performed syntax validation using `bash -n` on all modified scripts.
- Verified that the logic for Base64 encoding and header construction follows Azure DevOps authentication standards.
- Updated the Sentinel journal with prevention strategies for similar issues.

---
*PR created automatically by Jules for task [15893045589819695491](https://jules.google.com/task/15893045589819695491) started by @kobi070*