### PR TITLE
Add Azure DevOps repository tag watcher script and templates

### DIFF
--- a/az_devops_templates/README.md
+++ b/az_devops_templates/README.md
@@ -11,6 +11,7 @@ The templates are organized into three main categories:
 - `docker_build_push.yml`: Standardized workflow for building, scanning, and pushing Docker images.
 - `gitflow_logic.yml`: Shared logic for branch-based environment detection.
 - `jfrog_operations.yml`: Common tasks for interacting with JFrog Artifactory.
+- `tag_watcher_task.yml`: Checks for new tags in a repository and triggers a pipeline.
 
 ### 2. Standardized Jobs (`jobs/`)
 - `build_test_job.yml`: A multi-language job template supporting .NET, C++, Node.js, and Python.
@@ -21,6 +22,7 @@ The templates are organized into three main categories:
 ### 3. Pipeline Examples (`pipelines/`)
 Ready-to-use pipeline examples for different stacks:
 - `nodejs_pipeline.yml`, `python_pipeline.yml`, `dotnet_pipeline.yml`, `cpp_pipeline.yml`.
+- `utils/tag_watcher_pipeline.yml`: Scheduled pipeline to monitor multiple repositories for new tags.
 
 ## 🚀 Usage
 

--- a/az_devops_templates/common/tag_watcher_task.yml
+++ b/az_devops_templates/common/tag_watcher_task.yml
@@ -1,0 +1,31 @@
+parameters:
+  - name: organization
+    type: string
+  - name: project
+    type: string
+  - name: repository
+    type: string
+  - name: targetPipeline
+    type: string
+  - name: variableGroup
+    type: string
+  - name: variableName
+    type: string
+    default: ''
+  - name: displayName
+    type: string
+    default: 'Check for new tags and trigger pipeline'
+
+steps:
+  - script: |
+      bash $(System.DefaultWorkingDirectory)/az_scripts/az_repo_tag_watcher.sh \
+        --org "${{ parameters.organization }}" \
+        --project "${{ parameters.project }}" \
+        --repo "${{ parameters.repository }}" \
+        --pipeline "${{ parameters.targetPipeline }}" \
+        --group "${{ parameters.variableGroup }}" \
+        ${{ if ne(parameters.variableName, '') }}:
+          --variable "${{ parameters.variableName }}"
+    displayName: ${{ parameters.displayName }}
+    env:
+      AZURE_DEVOPS_EXT_PAT: $(AZ_DEVOPS_PAT)

--- a/az_devops_templates/pipelines/utils/tag_watcher_pipeline.yml
+++ b/az_devops_templates/pipelines/utils/tag_watcher_pipeline.yml
@@ -1,0 +1,51 @@
+# Tag Watcher Pipeline
+# This pipeline runs on a schedule and checks for new tags in specified repositories.
+# If a new tag is found, it triggers the corresponding CI pipeline.
+
+schedules:
+  - cron: "0 * * * *" # Every hour
+    displayName: Hourly tag check
+    branches:
+      include:
+        - main
+    always: true
+
+trigger: none # Disable CI trigger for this pipeline
+pr: none      # Disable PR trigger for this pipeline
+
+variables:
+  - group: tag-watcher-state # Variable group to store last seen tags
+  - name: organization
+    value: 'https://dev.azure.com/your-org'
+  - name: project
+    value: 'your-project'
+
+pool:
+  vmImage: 'ubuntu-latest'
+
+jobs:
+  - job: WatchTags
+    displayName: 'Watch Repositories for New Tags'
+    steps:
+      # Checkout the repository containing the scripts
+      - checkout: self
+
+      # Example 1: Monitor 'service-a' repository
+      - template: ../../common/tag_watcher_task.yml
+        parameters:
+          organization: $(organization)
+          project: $(project)
+          repository: 'service-a'
+          targetPipeline: 'service-a-ci'
+          variableGroup: 'tag-watcher-state'
+          displayName: 'Check service-a for new tags'
+
+      # Example 2: Monitor 'service-b' repository
+      - template: ../../common/tag_watcher_task.yml
+        parameters:
+          organization: $(organization)
+          project: $(project)
+          repository: 'service-b'
+          targetPipeline: 'service-b-ci'
+          variableGroup: 'tag-watcher-state'
+          displayName: 'Check service-b for new tags'

--- a/az_scripts/README.md
+++ b/az_scripts/README.md
@@ -20,6 +20,9 @@ This directory contains shell scripts for managing **Azure** resources and **Azu
 5. **az_list_repos.sh**
    Lists all repositories within an Azure DevOps project.
 
+6. **az_repo_tag_watcher.sh**
+   Monitors a repository for new tags and triggers a target pipeline, using a variable group for state persistence.
+
 ### Resource Management
 6. **az_script_advance.sh**
    An end-to-end script that creates a repo, pushes code, and sets up a CI/CD pipeline in Azure DevOps.

--- a/az_scripts/az_repo_tag_watcher.sh
+++ b/az_scripts/az_repo_tag_watcher.sh
@@ -1,0 +1,118 @@
+#!/bin/bash
+# az_repo_tag_watcher.sh
+# Monitors a repository for new tags and triggers a pipeline if a new tag is found.
+# It uses an Azure DevOps Variable Group to store the last seen tag for persistence.
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 --org <org_url> --project <project> --repo <repo_name> --pipeline <pipeline_name_or_id> --group <variable_group_name> [--variable <variable_name>]"
+    echo ""
+    echo "Options:"
+    echo "  --org       Azure DevOps Organization URL (e.g., https://dev.azure.com/org)"
+    echo "  --project   Project Name"
+    echo "  --repo      Repository Name to monitor"
+    echo "  --pipeline  Target Pipeline Name or ID to trigger"
+    echo "  --group     Variable Group Name to store the state"
+    echo "  --variable  (Optional) Variable Name in the group. Defaults to LAST_TAG_<REPO_NAME>"
+    exit 1
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --org) ORG="$2"; shift 2 ;;
+        --project) PROJECT="$2"; shift 2 ;;
+        --repo) REPO="$2"; shift 2 ;;
+        --pipeline) TARGET_PIPELINE="$2"; shift 2 ;;
+        --group) VAR_GROUP="$2"; shift 2 ;;
+        --variable) VAR_NAME="$2"; shift 2 ;;
+        -h|--help) usage ;;
+        *) echo "Unknown parameter: $1"; usage ;;
+    esac
+done
+
+# Validate required arguments
+if [[ -z "${ORG:-}" || -z "${PROJECT:-}" || -z "${REPO:-}" || -z "${TARGET_PIPELINE:-}" || -z "${VAR_GROUP:-}" ]]; then
+    usage
+fi
+
+# Default variable name if not provided
+if [[ -z "${VAR_NAME:-}" ]]; then
+    # Sanitize repo name for variable name (replace non-alphanumeric with underscore)
+    CLEAN_REPO=$(echo "$REPO" | sed 's/[^a-zA-Z0-9]/_/g')
+    VAR_NAME="LAST_TAG_${CLEAN_REPO}"
+fi
+
+# Check for required tools
+if ! command -v jq &> /dev/null; then
+    echo "Error: 'jq' not found. Please install it to run this script."
+    exit 1
+fi
+
+if ! command -v az &> /dev/null; then
+    echo "Error: Azure CLI ('az') not found."
+    exit 1
+fi
+
+if ! az extension show --name azure-devops &> /dev/null; then
+    echo "Error: Azure DevOps extension for CLI not found. Install with: az extension add --name azure-devops"
+    exit 1
+fi
+
+echo "Checking for new tags in repository: $REPO..."
+
+# 1. Fetch the latest tag from the repository
+LATEST_TAG=$(az repos ref list --repository "$REPO" --project "$PROJECT" --organization "$ORG" --filter tags/ --query "[].name" -o tsv | sed 's|refs/tags/||' | sort -V | tail -n 1)
+
+if [[ -z "$LATEST_TAG" ]]; then
+    echo "No tags found in repository $REPO. Skipping."
+    exit 0
+fi
+
+echo "Latest tag found: $LATEST_TAG"
+
+# 2. Get the variable group ID
+GROUP_ID=$(az pipelines variable-group list --project "$PROJECT" --organization "$ORG" --query "[?name=='$VAR_GROUP'].id" -o tsv)
+
+if [[ -z "$GROUP_ID" ]]; then
+    echo "Error: Variable group '$VAR_GROUP' not found in project '$PROJECT'."
+    exit 1
+fi
+
+# 3. Get the last seen tag from the variable group
+# Note: This assumes the variable exists in the group.
+LAST_SEEN_TAG=$(az pipelines variable-group show --group-id "$GROUP_ID" --project "$PROJECT" --organization "$ORG" --query "variables.\"$VAR_NAME\".value" -o tsv)
+
+echo "Last seen tag: ${LAST_SEEN_TAG:-None}"
+
+# 4. Compare tags
+if [[ "$LATEST_TAG" != "$LAST_SEEN_TAG" ]]; then
+    echo "New tag detected! Triggering pipeline '$TARGET_PIPELINE'..."
+
+    # Trigger the pipeline
+    # We pass the tag as a variable to the triggered pipeline if needed
+    RUN_INFO=$(az pipelines run --name "$TARGET_PIPELINE" --project "$PROJECT" --organization "$ORG" --variables "SOURCE_TAG=$LATEST_TAG" --output json)
+    RUN_ID=$(echo "$RUN_INFO" | jq -r '.id')
+
+    if [[ -n "$RUN_ID" && "$RUN_ID" != "null" ]]; then
+        echo "Successfully triggered pipeline. Run ID: $RUN_ID"
+
+        # 5. Update the variable group with the new tag
+        echo "Updating variable group state..."
+        if [[ -z "$LAST_SEEN_TAG" ]]; then
+            # Create variable if it doesn't exist (this is tricky with CLI, usually update is preferred)
+            # Actually variable-group variable create doesn't exist in some versions, but update works if it exists.
+            # To be safe, we assume the user pre-created the variable or we try to update.
+            az pipelines variable-group variable create --group-id "$GROUP_ID" --name "$VAR_NAME" --value "$LATEST_TAG" --project "$PROJECT" --organization "$ORG" > /dev/null
+        else
+            az pipelines variable-group variable update --group-id "$GROUP_ID" --name "$VAR_NAME" --value "$LATEST_TAG" --project "$PROJECT" --organization "$ORG" > /dev/null
+        fi
+        echo "State updated: $VAR_NAME=$LATEST_TAG"
+    else
+        echo "Error: Failed to trigger pipeline."
+        exit 1
+    fi
+else
+    echo "No new tags detected. Repository is up to date."
+fi


### PR DESCRIPTION
Implemented a solution for cross-repository tag monitoring in Azure DevOps. Since Azure DevOps doesn't natively support tag triggers for multiple repositories, this implementation uses a scheduled pipeline that polls the target repositories for new tags using the Azure CLI. State is maintained in a Variable Group to ensure only new tags trigger the target pipelines.

---
*PR created automatically by Jules for task [8818220156840002367](https://jules.google.com/task/8818220156840002367) started by @kobi070*