### PR TITLE
⚡ Bolt: optimize unused PVC detection logic

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -15,3 +15,7 @@
 ## 2026-05-15 - [Bash built-ins for string manipulation]
 **Learning:** External processes like `sed`, `cut`, and `tr` are often used for simple string sanitization and transformation, but they incur process fork overhead. Bash parameter expansion (`${VAR//search/replace}`, `${VAR#prefix}`, `${VAR%suffix}`) is executed directly by the shell and is significantly faster for these tasks.
 **Action:** Use Bash parameter expansion instead of piping to `sed` or `cut` for basic string manipulation in performance-critical or frequently executed scripts.
+
+## 2026-05-16 - [Set difference with grep -xvFf]
+**Learning:** Using `grep -vFf` to find the difference between two sets of data (e.g., finding unused resources) is significantly faster than a nested loop but can introduce bugs. Without `-x`, it performs substring matching, which can cause false positives (e.g., 'pvc1' matching 'pvc11'). Additionally, if the pattern file/input is empty, `grep` may match all lines or none depending on the implementation and input, often requiring an explicit check for empty sets.
+**Action:** Always use the `-x` flag for exact line matching and implement a check to ensure the pattern set is not empty before executing `grep` in set difference operations.

--- a/k8s_scripts/k8s_find_unused_pvcs.sh
+++ b/k8s_scripts/k8s_find_unused_pvcs.sh
@@ -51,16 +51,20 @@ USED_PVCS_WITH_NS=$(kubectl get pods $NAMESPACE_ARG -o json | jq -r '
   "\($pod.metadata.namespace)/\(.persistentVolumeClaim.claimName)"
 ' | sort -u)
 
-UNUSED_FOUND=false
-echo "NAMESPACE/NAME"
+# Identify unused PVCs by comparing the lists
+if [ -z "$USED_PVCS_WITH_NS" ]; then
+    # If no PVCs are used, all found PVCs are unused
+    UNUSED_PVCS="$ALL_PVCS"
+else
+    # Optimized: use grep -xvFf to find lines in ALL_PVCS that are not in USED_PVCS_WITH_NS.
+    # -x ensures exact line matching to avoid substring issues.
+    # This replaces an O(N*M) loop with nested process forks with a single, efficient O(N+M) process.
+    UNUSED_PVCS=$(grep -xvFf <(echo "$USED_PVCS_WITH_NS") <(echo "$ALL_PVCS") || true)
+fi
 
-for pvc in $ALL_PVCS; do
-    if ! echo "$USED_PVCS_WITH_NS" | grep -q "^$pvc$"; then
-        echo "$pvc"
-        UNUSED_FOUND=true
-    fi
-done
-
-if [ "$UNUSED_FOUND" = false ]; then
+if [ -z "$UNUSED_PVCS" ]; then
     echo "No unused PVCs found."
+else
+    echo "NAMESPACE/NAME"
+    echo "$UNUSED_PVCS"
 fi


### PR DESCRIPTION
This PR optimizes the `k8s_find_unused_pvcs.sh` script by replacing an inefficient loop with a high-performance set difference operation.

### Changes:
- Replaced the `for` loop that iterated over all PVCs with a single `grep -xvFf` command.
- Added a check for empty `USED_PVCS_WITH_NS` to ensure correctness when no PVCs are in use.
- Used the `-x` flag with `grep` to ensure exact line matching, preventing substring matching bugs (e.g., `pvc1` matching `pvc11`).

### Performance Impact:
- **Process Forks:** Reduced from $O(N)$ to $O(1)$ during the comparison phase.
- **Complexity:** Improved from $O(N \times M)$ to $O(N+M)$, where $N$ is the number of PVCs and $M$ is the number of used PVCs.

### Verification:
- Verified syntax with `bash -n`.
- Verified logic with a mock-based test suite covering:
  - Standard unused resource detection.
  - Substring match prevention (exact matching).
  - Empty pattern set handling (no resources used).
  - No unused resources found.

---
*PR created automatically by Jules for task [54731806732561597](https://jules.google.com/task/54731806732561597) started by @kobi070*