### PR TITLE
🛡️ Sentinel: [HIGH] Fix secret exposure in process lists for curl-based scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** Decoded Kubernetes secrets are printed directly to stdout, which can be captured in CI/CD logs or persistent shell history if redirected.
 **Learning:** DevOps utility scripts are often used in both interactive debugging and non-interactive CI/CD contexts. Without checking the terminal type, sensitive data is indiscriminately logged in persistent storage.
 **Prevention:** Implement a check for an interactive terminal (`[ -t 1 ]`) before printing sensitive data. Redact secrets by default in non-interactive modes, providing an explicit override flag (e.g., `--raw`) for authorized automated extraction.
+
+## 2025-05-18 - Secret Exposure in Process Lists via Curl Headers
+**Vulnerability:** Passing sensitive headers to `curl` using the `-H` flag (e.g., `-H "Authorization: token $TOKEN"`) makes the secrets visible in the system's process list (via `ps` or `/proc`) during the entire duration of the network request.
+**Learning:** Even when scripts correctly use environment variables, the final call to a CLI tool can re-expose those secrets if they are passed as command-line arguments.
+**Prevention:** Use `curl`'s `--config -` (or `-K-`) option to pass sensitive headers via standard input. Using `printf` (a shell builtin) to pipe the configuration ensures the secret is never part of an `argv` array for an external process.

--- a/github_scripts/gh_create_release.sh
+++ b/github_scripts/gh_create_release.sh
@@ -59,8 +59,8 @@ PAYLOAD=$(jq -n \
     '{tag_name: $tag, name: $name, body: $body, draft: false, prerelease: false}')
 
 # Send the request
-RESPONSE=$(curl -s -X POST \
-    -H "Authorization: token $GITHUB_TOKEN" \
+# Use curl config file via stdin to prevent leaking GITHUB_TOKEN in process lists (ps)
+RESPONSE=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | curl -s -X POST -K- \
     -H "Accept: application/vnd.github.v3+json" \
     -d "$PAYLOAD" \
     "https://api.github.com/repos/$REPO/releases")

--- a/github_scripts/gh_list_collaborators.sh
+++ b/github_scripts/gh_list_collaborators.sh
@@ -40,18 +40,18 @@ if ! command -v jq &> /dev/null; then
     exit 1
 fi
 
-AUTH_ARGS=()
-if [ -n "${GITHUB_TOKEN:-}" ]; then
-    AUTH_ARGS=(-H "Authorization: token $GITHUB_TOKEN")
-fi
-
 echo "Fetching collaborators for $OWNER/$REPO..."
 
 # Fetch collaborators using GitHub API
 # Handles pagination (basic - up to 100 collaborators)
 API_URL="https://api.github.com/repos/$OWNER/$REPO/collaborators?per_page=100"
 
-RESPONSE=$(curl -s "${AUTH_ARGS[@]}" -H "Accept: application/vnd.github+json" "$API_URL")
+# Use curl config file via stdin to prevent leaking GITHUB_TOKEN in process lists (ps)
+if [ -n "${GITHUB_TOKEN:-}" ]; then
+    RESPONSE=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | curl -s -K- -H "Accept: application/vnd.github+json" "$API_URL")
+else
+    RESPONSE=$(curl -s -H "Accept: application/vnd.github+json" "$API_URL")
+fi
 
 # Check for errors in response
 if echo "$RESPONSE" | jq -e '.message' > /dev/null; then

--- a/jfrog_scripts/pull_generic.sh
+++ b/jfrog_scripts/pull_generic.sh
@@ -20,8 +20,8 @@ done
 SOURCE_PATH="$1"
 OUTPUT_FILENAME="$2"
 
-# Removed -v to prevent leaking JFROG_API_KEY in logs
-curl -sS -H "X-JFrog-Art-Api: $JFROG_API_KEY" \
+# Use curl config file via stdin to prevent leaking JFROG_API_KEY in process lists (ps)
+printf "header = \"X-JFrog-Art-Api: %s\"\n" "$JFROG_API_KEY" | curl -sS -K- \
      -L -o "$OUTPUT_FILENAME" \
      "$JFROG_URL/$JFROG_REPO/$SOURCE_PATH"
 

--- a/jfrog_scripts/upload_generic.sh
+++ b/jfrog_scripts/upload_generic.sh
@@ -25,9 +25,8 @@ if [ ! -f "$LOCAL_FILE" ]; then
   exit 1
 fi
 
-# Removed -v to prevent leaking JFROG_API_KEY in logs
-curl -sS \
-  -H "X-JFrog-Art-Api: $JFROG_API_KEY" \
+# Use curl config file via stdin to prevent leaking JFROG_API_KEY in process lists (ps)
+printf "header = \"X-JFrog-Art-Api: %s\"\n" "$JFROG_API_KEY" | curl -sS -K- \
   -H "Content-Type: application/octet-stream" \
   -T "$LOCAL_FILE" \
   "$JFROG_URL/$JFROG_REPO/$TARGET_PATH"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Passing sensitive headers (Authorization, X-JFrog-Art-Api) to `curl` using the `-H` flag exposes secrets in the process list (`ps`).
🎯 Impact: Any user or malicious process on the same system can see the secrets by listing running processes.
🔧 Fix: Updated scripts to use `curl --config -` (`-K-`) to pass sensitive headers via standard input using `printf` (shell builtin).
✅ Verification: Created a mock `curl` binary that logs its arguments and confirmed that secrets are no longer visible in the `argv` array. Verified syntax of all scripts with `bash -n`.

---
*PR created automatically by Jules for task [13103028251852988688](https://jules.google.com/task/13103028251852988688) started by @kobi070*