### PR TITLE
🛡️ Sentinel: [HIGH] Fix GITHUB_TOKEN exposure in process list for GitHub scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -26,3 +26,8 @@
 **Vulnerability:** Workloads running without PodDisruptionBudgets (PDB) are at risk of downtime during node maintenance. Running containers as root increases the blast radius of a container escape.
 **Learning:** Correlating Kubernetes resources (Deployments/PDBs) in shell scripts is most efficient when fetching both as JSON and using `jq` for label matching, rather than multiple `kubectl` calls.
 **Prevention:** Implement automated PDB auditing and container root-check scripts to "left-shift" these availability and security checks.
+
+## 2026-05-19 - GITHUB_TOKEN Exposure in Process List via curl Headers
+**Vulnerability:** Using `curl -H "Authorization: token $GITHUB_TOKEN"` exposes the sensitive token in the system's process list (visible via `ps`), making it accessible to other users or logging tools on the same host.
+**Learning:** While environment variables are safer than positional arguments, passing them as command-line flags to external binaries still leaks them into the process table.
+**Prevention:** Use `curl`'s `--config -` (or `-K-`) flag to pass sensitive headers via standard input. By piping the header string directly to `curl`, the secret never appears in the command-line arguments.

--- a/github_scripts/gh_pr_size_checker.sh
+++ b/github_scripts/gh_pr_size_checker.sh
@@ -46,8 +46,8 @@ REPO=$1
 echo "Fetching open PRs for $REPO..."
 
 # Fetch open PRs (first 100)
-PRS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    -H "Accept: application/vnd.github.v3+json" \
+PRS=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+    curl -s -K- -H "Accept: application/vnd.github.v3+json" \
     "https://api.github.com/repos/$REPO/pulls?state=open&per_page=100")
 
 # Check if PRS is an array
@@ -71,8 +71,8 @@ echo "--------------------------------------------------------------------------
 
 echo "$PRS" | jq -r '.[] | [.number, .title, .url] | @tsv' | while IFS=$'\t' read -r NUM TITLE URL; do
     # Fetch PR details for additions/deletions
-    DETAILS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-        -H "Accept: application/vnd.github.v3+json" \
+    DETAILS=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+        curl -s -K- -H "Accept: application/vnd.github.v3+json" \
         "$URL")
 
     ADDITIONS=$(echo "$DETAILS" | jq -r '.additions // 0')

--- a/github_scripts/gh_workflow_failure_logs.sh
+++ b/github_scripts/gh_workflow_failure_logs.sh
@@ -43,8 +43,8 @@ WORKFLOW=$2
 echo "Fetching last failed run for $WORKFLOW in $REPO..."
 
 # Get the latest failed run ID
-RUN_ID=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    "https://api.github.com/repos/$REPO/actions/workflows/$WORKFLOW/runs?status=failure&per_page=1" \
+RUN_ID=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+    curl -s -K- "https://api.github.com/repos/$REPO/actions/workflows/$WORKFLOW/runs?status=failure&per_page=1" \
     | jq -r '.workflow_runs[0].id')
 
 if [ "$RUN_ID" == "null" ] || [ -z "$RUN_ID" ]; then
@@ -55,8 +55,8 @@ fi
 echo "Found failed run ID: $RUN_ID. Fetching jobs..."
 
 # Get jobs data for the failed run once
-JOBS_DATA=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-    "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/jobs")
+JOBS_DATA=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+    curl -s -K- "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/jobs")
 
 # Extract IDs and names of failed jobs
 # We use a custom separator to handle job names with spaces
@@ -70,8 +70,8 @@ echo "$FAILED_JOBS" | while IFS='|' read -r JOB_ID JOB_NAME; do
     echo "---------------------------------------------------------"
 
     # Fetch logs for the job
-    curl -s -H "Authorization: token $GITHUB_TOKEN" \
-        -L "https://api.github.com/repos/$REPO/actions/jobs/$JOB_ID/logs"
+    printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+        curl -s -K- -L "https://api.github.com/repos/$REPO/actions/jobs/$JOB_ID/logs"
 
     echo ""
 done

--- a/tests/verify_curl_scripts.sh
+++ b/tests/verify_curl_scripts.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -euo pipefail
+
+MOCK_BIN=$(mktemp -d)
+export PATH="$MOCK_BIN:$PATH"
+export GITHUB_TOKEN="mock_token"
+
+# Cleanup on exit
+trap 'rm -rf "$MOCK_BIN"' EXIT
+
+# Mock curl to verify it receives the header via stdin
+cat <<'MOCKCURL' > "$MOCK_BIN/curl"
+#!/bin/bash
+# Check if -K- is used
+HAS_K_STDIN=false
+for arg in "$@"; do
+    if [[ "$arg" == "-K-" ]]; then
+        HAS_K_STDIN=true
+    fi
+done
+
+if [ "$HAS_K_STDIN" = true ]; then
+    # Read from stdin to see if it contains the token
+    STDIN_CONTENT=$(cat -)
+    if echo "$STDIN_CONTENT" | grep -q "Authorization: token mock_token"; then
+        # Return a mock JSON response for the scripts to continue
+        if [[ "$*" == *"pulls"* ]] && [[ "$*" != *"pulls/1"* ]]; then
+            echo '[{"number": 1, "title": "Test PR", "url": "https://api.github.com/repos/owner/repo/pulls/1"}]'
+        elif [[ "$*" == *"pulls/1"* ]]; then
+             echo '{"additions": 10, "deletions": 5}'
+        elif [[ "$*" == *"runs?status=failure"* ]]; then
+            echo '{"workflow_runs": [{"id": 123}]}'
+        elif [[ "$*" == *"runs/123/jobs"* ]]; then
+            echo '{"jobs": [{"id": 456, "name": "test-job", "conclusion": "failure"}]}'
+        elif [[ "$*" == *"jobs/456/logs"* ]]; then
+            echo "Mock logs content"
+        else
+            echo "{}"
+        fi
+    else
+        echo "Error: Authorization header not found in stdin" >&2
+        kill -s TERM $PPID
+    fi
+else
+    # Check if it was passed as -H (old insecure way)
+    if [[ "$*" == *"Authorization: token"* ]]; then
+         echo "Error: Insecure Authorization header found in arguments" >&2
+         kill -s TERM $PPID
+    fi
+    echo "Error: curl called without -K-" >&2
+    kill -s TERM $PPID
+fi
+MOCKCURL
+chmod +x "$MOCK_BIN/curl"
+
+echo "Verifying gh_pr_size_checker.sh..."
+./github_scripts/gh_pr_size_checker.sh owner/repo > /tmp/out 2>&1 || (cat /tmp/out; false)
+if grep -q "#1" /tmp/out; then
+    echo "  ✔ gh_pr_size_checker.sh passed verification"
+else
+    echo "  ✖ gh_pr_size_checker.sh failed verification"
+    cat /tmp/out
+    false
+fi
+
+echo "Verifying gh_workflow_failure_logs.sh..."
+./github_scripts/gh_workflow_failure_logs.sh owner/repo ci.yml > /tmp/out 2>&1 || (cat /tmp/out; false)
+if grep -q "Mock logs content" /tmp/out; then
+    echo "  ✔ gh_workflow_failure_logs.sh passed verification"
+else
+    echo "  ✖ gh_workflow_failure_logs.sh failed verification"
+    cat /tmp/out
+    false
+fi
+
+echo "All curl-based scripts verified!"


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: GITHUB_TOKEN was being passed as a command-line argument to `curl` via the `-H "Authorization: token ..."` flag.
🎯 Impact: This makes the token visible in the system's process list (e.g., via `ps aux`) to any user on the machine, which is a significant security risk in shared or multi-tenant environments.
🔧 Fix: Implemented the secure `curl -K-` pattern. The authorization header is now piped into `curl`'s standard input, preventing it from appearing in the process table.
✅ Verification: Created a new test suite `tests/verify_curl_scripts.sh` that mocks `curl` and verifies that it receives the token via stdin and NOT via command-line arguments. All tests passed.

---
*PR created automatically by Jules for task [13655609912652999583](https://jules.google.com/task/13655609912652999583) started by @kobi070*