### PR TITLE
⚡ Bolt: optimize gh_pr_stats.sh by reducing process forks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -25,3 +25,7 @@
 ## 2026-05-18 - High-Performance Workflow Analytics and IAM Audits
 **Learning:** In `jq`, performing numeric calculations (like date differences) can lose the object context. Assigning fields to variables (e.g., `.AccessKeyId as $id`) before the calculation ensures they remain accessible for the final output string, avoiding "Cannot index number with string" errors.
 **Action:** Consistently use `jq` variables for field extraction in scripts involving multi-stage JSON transformations.
+
+## 2026-05-19 - [jq Operator Precedence with Variable Assignment]
+**Learning:** In `jq`, the division operator (`/`) has higher precedence than variable assignment (`as`). Attempting a calculation like `A - B / 3600 as $h` results in `jq` trying to divide `B` by the string `"as $h ..."`, leading to a type error. Parenthesizing the entire calculation is required.
+**Action:** Always parenthesize complex calculations in `jq` filters before assigning the result to a variable: `((.mergedAt | fromdateiso8601) - (.createdAt | fromdateiso8601)) / 3600 as $diff_hours`.

--- a/github_scripts/gh_pr_stats.sh
+++ b/github_scripts/gh_pr_stats.sh
@@ -51,26 +51,31 @@ echo "--------------------------------------------------------------------------
 echo "PR #   | Merged At            | Duration (Hours) | Title"
 echo "--------------------------------------------------------------------------------"
 
-# Process PRs and calculate stats
-# Note: We use awk for date arithmetic because bc is not available and bash lacks floating point
-echo "$PR_DATA" | jq -r '.[] | "\(.number)\t\(.mergedAt)\t\(.createdAt)\t\(.title)"' | while IFS=$'\t' read -r num merged created title; do
-    # Convert ISO 8601 to epoch (requires GNU date or compatible)
-    CREATED_EPOCH=$(date -d "$created" +%s)
-    MERGED_EPOCH=$(date -d "$merged" +%s)
-
-    DIFF_SECONDS=$((MERGED_EPOCH - CREATED_EPOCH))
-    # Using awk for division to get decimal hours
-    DIFF_HOURS=$(awk "BEGIN {printf \"%.2f\", $DIFF_SECONDS / 3600}")
-
-    printf "%-6s | %-20s | %-16s | %s\n" "$num" "${merged:0:19}" "$DIFF_HOURS" "${title:0:40}"
+# Bolt optimization: Move all date arithmetic and string manipulation into a single jq process.
+# This eliminates 2x 'date' and 1x 'awk' process forks per pull request (3*N forks total).
+# We calculate duration in hours and format fields directly in jq.
+# The shell loop now only uses the 'printf' builtin for consistent decimal formatting.
+echo "$PR_DATA" | jq -r '
+  .[] |
+  .number as $num |
+  .mergedAt as $merged |
+  .createdAt as $created |
+  .title as $title |
+  ((($merged | fromdateiso8601) - ($created | fromdateiso8601)) / 3600) as $diff_hours |
+  "\($num)\t\($merged[0:19])\t\($diff_hours)\t\($title[0:40])"
+' | while IFS=$'\t' read -r num merged diff_hours title; do
+    printf "%-6s | %-20s | %-16.2f | %s\n" "$num" "$merged" "$diff_hours" "$title"
 done
 
 # Calculate overall average
-AVG_HOURS=$(echo "$PR_DATA" | jq -r '.[] | .createdAt as $c | .mergedAt as $m | ( ($m | fromdateiso8601) - ($c | fromdateiso8601) )' | \
-    awk '{ sum += $1; count++ } END { if (count > 0) printf "%.2f", (sum / count) / 3600; else print "0" }')
+# Bolt optimization: Reuse the already fetched PR_DATA
+AVG_HOURS=$(echo "$PR_DATA" | jq -r '
+  [ .[] | ( (.mergedAt | fromdateiso8601) - (.createdAt | fromdateiso8601) ) ] |
+  if length > 0 then (add / length) / 3600 else 0 end
+')
 
 echo "--------------------------------------------------------------------------------"
 echo "SUMMARY:"
 echo "Analyzed PRs: $(echo "$PR_DATA" | jq '. | length')"
-echo "Average Time-to-Merge: $AVG_HOURS hours"
+printf "Average Time-to-Merge: %.2f hours\n" "$AVG_HOURS"
 echo "--------------------------------------------------------------------------------"


### PR DESCRIPTION
💡 What: Optimized the pull request statistics script by moving date arithmetic and string manipulation into a single `jq` process and using Bash built-ins for formatting.

🎯 Why: The original script forked `date` twice and \`awk\` once for every pull request in the loop, creating a significant performance bottleneck and using non-portable \`date -d\` syntax.

📊 Impact: Reduces process forks from O(N) to O(1), eliminating approximately 90 process forks for the default run of 30 PRs. Improves portability across Linux and macOS.

🔬 Measurement: Verified with \`tests/test_gh_pr_stats_opt.sh\` using mocked GitHub CLI data to ensure correct duration and average calculations.

---
*PR created automatically by Jules for task [3270607529411727200](https://jules.google.com/task/3270607529411727200) started by @kobi070*