### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell arithmetic injection in gh_stale_branches.sh

### DIFF
--- a/github_scripts/gh_stale_branches.sh
+++ b/github_scripts/gh_stale_branches.sh
@@ -25,6 +25,13 @@ fi
 
 REPO=$1
 DAYS=${2:-$DEFAULT_DAYS}
+
+# Security check: Ensure DAYS is a numeric integer to prevent shell arithmetic injection
+if [[ ! "$DAYS" =~ ^[0-9]+$ ]]; then
+    echo "Error: days must be a positive numeric integer."
+    exit 1
+fi
+
 THRESHOLD_SEC=$((DAYS * 24 * 3600))
 NOW_SEC=$(date +%s)
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Shell arithmetic injection in `github_scripts/gh_stale_branches.sh`. The `days` parameter was used in a `$(( ))` context without validation, allowing command execution.
🎯 Impact: An attacker could execute arbitrary commands if they can control the arguments passed to the script (e.g., in a CI/CD environment).
🔧 Fix: Added a regex-based numeric validation check `[[ ! "$DAYS" =~ ^[0-9]+$ ]]` to ensure only positive integers are processed.
✅ Verification: Confirmed command execution via a malicious payload in a mock environment, then verified that the payload is blocked after the fix. Existing tests in `./tests/verify_all.sh` also pass.

---
*PR created automatically by Jules for task [615522528362815648](https://jules.google.com/task/615522528362815648) started by @kobi070*