### PR TITLE
🛡️ Sentinel: [HIGH] Fix secret leakage in jfrog_config.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** Fragile error handling when parsing API responses can lead to script failures or bypassed security checks if the JSON structure changes between success (e.g., an array) and error (an object).
 **Learning:** GitHub list APIs return an array on success. Attempting to check for an error field like `.message` using `jq` on an array results in a fatal error: `Cannot index array with string "message"`.
 **Prevention:** Use the optional indexing operator `?` in `jq` (e.g., `jq -e '.message?'`) to safely probe for error fields. This allows the same check to work whether the response is an error object or a successful array of items, ensuring consistent error detection.
+
+## 2025-05-24 - Secret Exposure in Process Lists via JFrog CLI Flags
+**Vulnerability:** Passing passwords or tokens to the JFrog CLI using the `--password` flag (e.g., `jf c add ... --password=$PASS`) makes them visible to all users on the system via process monitoring tools like `ps`.
+**Learning:** Many CLI tools provide command-line flags for authentication for convenience, but these are insecure for non-interactive use in shared environments or CI/CD runners.
+**Prevention:** Always prioritize using environment variables supported by the CLI (e.g., `JFROG_CLI_PASSWORD`) for sensitive information. Explicitly unset or avoid passing these secrets as command-line arguments.

--- a/jfrog_scripts/jfrog_config.sh
+++ b/jfrog_scripts/jfrog_config.sh
@@ -60,10 +60,11 @@ echo "Configuring JFrog CLI for server: $SERVER_ID..."
 
 # Configure the server
 # Use --overwrite to ensure we update if it already exists
+# We use an environment variable to prevent secret leakage in process lists.
+export JFROG_CLI_PASSWORD="$PASSWORD"
 $JF_BIN c add "$SERVER_ID" \
     --url="$URL" \
     --user="$USER" \
-    --password="$PASSWORD" \
     --interactive=false \
     --overwrite
 

--- a/tests/verify_all.sh
+++ b/tests/verify_all.sh
@@ -468,6 +468,16 @@ if [[ "$*" == *"rt repo-list"* ]]; then
   echo '[{"key": "empty-local", "type": "local"}]'
 elif [[ "$*" == *"rt s"* ]]; then
   echo "0"
+elif [[ "$*" == *"c add"* ]]; then
+  if [[ "$*" == *"--password"* ]]; then
+    echo "Error: Password passed as command-line argument!" >&2
+    exit 1
+  fi
+  if [[ -z "${JFROG_CLI_PASSWORD:-}" ]]; then
+    echo "Error: JFROG_CLI_PASSWORD environment variable not set!" >&2
+    exit 1
+  fi
+  echo "Success: Server configured securely"
 fi
 EOF
 chmod +x "$MOCK_BIN/jf"
@@ -477,6 +487,14 @@ if ./jfrog_scripts/jf_list_empty_repos.sh local 2>&1 | grep -q "empty-local"; th
     echo "  ✔ Found empty repository"
 else
     echo "  ✖ Failed to find empty repository"
+    exit 1
+fi
+
+echo "Testing jfrog_config.sh security..."
+if ./jfrog_scripts/jfrog_config.sh my-server http://localhost admin my-secret 2>&1 | grep -q "Success: Server configured securely"; then
+    echo "  ✔ jfrog_config.sh passed security verification"
+else
+    echo "  ✖ jfrog_config.sh failed security verification"
     exit 1
 fi
 


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Secret leakage in system process lists via CLI flags.
🎯 Impact: Sensitive credentials (passwords/tokens) could be harvested by any user or logging process on the same host.
🔧 Fix: Switched to using the `JFROG_CLI_PASSWORD` environment variable, which is natively supported by the JFrog CLI and prevents exposure in `ps` output.
✅ Verification: Added an automated test in `tests/verify_all.sh` that mocks the `jf` binary and asserts that `--password` is absent from arguments while the environment variable is present. All tests passed.

---
*PR created automatically by Jules for task [17466781414361430949](https://jules.google.com/task/17466781414361430949) started by @kobi070*