### PR TITLE
🛡️ Sentinel: Harden secret handling in JFrog CLI configuration

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -47,3 +47,8 @@
 **Vulnerability:** Fragile error handling when parsing API responses can lead to script failures or bypassed security checks if the JSON structure changes between success (e.g., an array) and error (an object).
 **Learning:** GitHub list APIs return an array on success. Attempting to check for an error field like `.message` using `jq` on an array results in a fatal error: `Cannot index array with string "message"`.
 **Prevention:** Use the optional indexing operator `?` in `jq` (e.g., `jq -e '.message?'`) to safely probe for error fields. This allows the same check to work whether the response is an error object or a successful array of items, ensuring consistent error detection.
+
+## 2026-05-28 - JFrog CLI Password Exposure in Process List
+**Vulnerability:** Passing the Artifactory password or token using the `--password` flag to the JFrog CLI (`jf c add`) exposes it in the system's process list (visible via `ps`).
+**Learning:** Unlike `curl`, the JFrog CLI does not support a "config file via stdin" pattern for all its commands. However, it respects specific environment variables like `JFROG_CLI_PASSWORD` for authentication during configuration.
+**Prevention:** Prioritize using the `JFROG_CLI_PASSWORD` environment variable when configuring the JFrog CLI. Avoid passing secrets via the `--password` flag to prevent leakage into the process table.

--- a/jfrog_scripts/jfrog_config.sh
+++ b/jfrog_scripts/jfrog_config.sh
@@ -60,13 +60,15 @@ echo "Configuring JFrog CLI for server: $SERVER_ID..."
 
 # Configure the server
 # Use --overwrite to ensure we update if it already exists
+# Use JFROG_CLI_PASSWORD env var to avoid leaking secrets in the process list
+export JFROG_CLI_PASSWORD="$PASSWORD"
 $JF_BIN c add "$SERVER_ID" \
     --url="$URL" \
     --user="$USER" \
-    --password="$PASSWORD" \
     --interactive=false \
     --overwrite
 
+unset JFROG_CLI_PASSWORD
 echo "Success: JFrog CLI configured for $SERVER_ID."
 
 # Set as default

--- a/tests/verify_all.sh
+++ b/tests/verify_all.sh
@@ -461,10 +461,22 @@ else
     exit 1
 fi
 
-# --- 22. Mock for jf_list_empty_repos.sh ---
+# --- 22. Mock for jf_list_empty_repos.sh and jfrog_config.sh ---
 cat <<'EOF' > "$MOCK_BIN/jf"
 #!/bin/bash
-if [[ "$*" == *"rt repo-list"* ]]; then
+if [[ "$*" == *"c add"* ]]; then
+  if [[ "$*" == *"--password"* ]]; then
+    echo "SECURITY ERROR: --password flag detected in process arguments!"
+    exit 1
+  fi
+  if [ -z "$JFROG_CLI_PASSWORD" ]; then
+    echo "ERROR: JFROG_CLI_PASSWORD environment variable not set!"
+    exit 1
+  fi
+  echo "Mock jf: Configured $3"
+elif [[ "$*" == *"c use"* ]]; then
+  echo "Mock jf: Using $3"
+elif [[ "$*" == *"rt repo-list"* ]]; then
   echo '[{"key": "empty-local", "type": "local"}]'
 elif [[ "$*" == *"rt s"* ]]; then
   echo "0"
@@ -477,6 +489,14 @@ if ./jfrog_scripts/jf_list_empty_repos.sh local 2>&1 | grep -q "empty-local"; th
     echo "  ✔ Found empty repository"
 else
     echo "  ✖ Failed to find empty repository"
+    exit 1
+fi
+
+echo "Testing jfrog_config.sh (Security Hardening)..."
+if JFROG_PASSWORD="mock_password" ./jfrog_scripts/jfrog_config.sh my-server http://jfrog.example.com admin 2>&1 | grep -q "Success: JFrog CLI configured"; then
+    echo "  ✔ Hardened JFrog configuration successful"
+else
+    echo "  ✖ Failed hardened JFrog configuration check"
     exit 1
 fi
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Harden secret handling in JFrog CLI configuration

🚨 Severity: HIGH
💡 Vulnerability: Passing Artifactory credentials via the `--password` flag to the JFrog CLI (`jf c add`) makes them visible in the system process list (e.g., via `ps -ef`), exposing them to other users and logging mechanisms.
🎯 Impact: Unauthorized access to the JFrog Artifactory instance if credentials are captured by malicious actors or stored in persistent logs.
🔧 Fix: Updated `jfrog_scripts/jfrog_config.sh` to use the `JFROG_CLI_PASSWORD` environment variable instead of the command-line flag. The variable is exported just before the CLI call and unset immediately after to minimize the exposure window.
✅ Verification:
1. Updated `tests/verify_all.sh` with a mock `jf` binary that explicitly checks for the `--password` flag and fails if it is present.
2. Verified that `jfrog_config.sh` successfully passes the new test case.
3. Ran all existing verification suites (`./tests/verify_all.sh` and `./tests/verify_curl_scripts.sh`) to ensure no regressions.

---
*PR created automatically by Jules for task [7977011021454575461](https://jules.google.com/task/7977011021454575461) started by @kobi070*