### PR TITLE
🛡️ Sentinel: [HIGH] Fix potential shell injection and standardize GitHub auth

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -56,3 +56,8 @@
 **Vulnerability:** Passing the Artifactory password or token using the `--password` flag to the JFrog CLI (`jf c add`) exposes it in the system's process list (visible via `ps`).
 **Learning:** Unlike `curl`, the JFrog CLI does not support a "config file via stdin" pattern for all its commands. However, it respects specific environment variables like `JFROG_CLI_PASSWORD` for authentication during configuration.
 **Prevention:** Prioritize using the `JFROG_CLI_PASSWORD` environment variable when configuring the JFrog CLI. Avoid passing secrets via the `--password` flag to prevent leakage into the process table.
+
+## 2025-05-31 - GitHub Bearer Tokens and Safe API Arithmetic
+**Vulnerability:** Use of deprecated `token` keyword in Authorization headers and potential shell arithmetic injection when processing numeric fields from API responses.
+**Learning:** GitHub's API has standardized on `Bearer` for authentication tokens. Additionally, processing numbers from JSON in shell arithmetic `$(($VAR))` is risky if the variable is unvalidated. Performing calculations within `jq` ensures data is treated as JSON numbers, providing defense-in-depth.
+**Prevention:** Always use `Bearer` for GitHub Authorization headers. Prioritize performing arithmetic and conditional logic (categorization) within `jq` rather than the shell when processing API data.

--- a/github_scripts/gh_create_release.sh
+++ b/github_scripts/gh_create_release.sh
@@ -60,7 +60,7 @@ PAYLOAD=$(jq -n \
 
 # Send the request
 # Use curl config file via stdin to prevent leaking GITHUB_TOKEN in process lists (ps)
-RESPONSE=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | curl -s -X POST -K- \
+RESPONSE=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | curl -s -X POST -K- \
     -H "Accept: application/vnd.github.v3+json" \
     -d "$PAYLOAD" \
     "https://api.github.com/repos/$REPO/releases")

--- a/github_scripts/gh_list_collaborators.sh
+++ b/github_scripts/gh_list_collaborators.sh
@@ -48,7 +48,7 @@ API_URL="https://api.github.com/repos/$OWNER/$REPO/collaborators?per_page=100"
 
 # Use curl config file via stdin to prevent leaking GITHUB_TOKEN in process lists (ps)
 if [ -n "${GITHUB_TOKEN:-}" ]; then
-    RESPONSE=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | curl -s -K- -H "Accept: application/vnd.github+json" "$API_URL")
+    RESPONSE=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | curl -s -K- -H "Accept: application/vnd.github+json" "$API_URL")
 else
     RESPONSE=$(curl -s -H "Accept: application/vnd.github+json" "$API_URL")
 fi

--- a/github_scripts/gh_list_pull_requests.sh
+++ b/github_scripts/gh_list_pull_requests.sh
@@ -48,7 +48,7 @@ API_URL="https://api.github.com/repos/$REPO/pulls?state=$STATE"
 
 # Use curl config file via stdin to prevent leaking GITHUB_TOKEN in process lists (ps)
 if [ -n "${GITHUB_TOKEN:-}" ]; then
-    PRS=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | curl -s -K- -H "Accept: application/vnd.github.v3+json" "$API_URL")
+    PRS=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | curl -s -K- -H "Accept: application/vnd.github.v3+json" "$API_URL")
 else
     PRS=$(curl -s -H "Accept: application/vnd.github.v3+json" "$API_URL")
 fi

--- a/github_scripts/gh_pr_size_checker.sh
+++ b/github_scripts/gh_pr_size_checker.sh
@@ -46,7 +46,7 @@ REPO=$1
 echo "Fetching open PRs for $REPO..."
 
 # Fetch open PRs (first 100)
-PRS=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+PRS=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | \
     curl -s -K- -H "Accept: application/vnd.github.v3+json" \
     "https://api.github.com/repos/$REPO/pulls?state=open&per_page=100")
 
@@ -71,20 +71,21 @@ echo "--------------------------------------------------------------------------
 
 echo "$PRS" | jq -r '.[] | [.number, .title, .url] | @tsv' | while IFS=$'\t' read -r NUM TITLE URL; do
     # Fetch PR details for additions/deletions
-    DETAILS=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+    DETAILS=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | \
         curl -s -K- -H "Accept: application/vnd.github.v3+json" \
         "$URL")
 
-    ADDITIONS=$(echo "$DETAILS" | jq -r '.additions // 0')
-    DELETIONS=$(echo "$DETAILS" | jq -r '.deletions // 0')
-    TOTAL=$((ADDITIONS + DELETIONS))
-
-    SIZE="XS"
-    if [ "$TOTAL" -ge 500 ]; then SIZE="XL";
-    elif [ "$TOTAL" -ge 200 ]; then SIZE="L";
-    elif [ "$TOTAL" -ge 50 ]; then SIZE="M";
-    elif [ "$TOTAL" -ge 10 ]; then SIZE="S";
-    fi
+    # Bolt optimization: Perform arithmetic and categorization within jq to prevent shell injection
+    SIZE_INFO=$(echo "$DETAILS" | jq -r '
+      ((.additions // 0) + (.deletions // 0)) as $total |
+      (if $total >= 500 then "XL"
+       elif $total >= 200 then "L"
+       elif $total >= 50 then "M"
+       elif $total >= 10 then "S"
+       else "XS" end) as $size |
+      "\($total)\t\($size)"
+    ')
+    IFS=$'\t' read -r TOTAL SIZE <<< "$SIZE_INFO"
 
     # Truncate title if too long
     TRUNC_TITLE="${TITLE:0:47}"

--- a/github_scripts/gh_workflow_failure_logs.sh
+++ b/github_scripts/gh_workflow_failure_logs.sh
@@ -43,7 +43,7 @@ WORKFLOW=$2
 echo "Fetching last failed run for $WORKFLOW in $REPO..."
 
 # Get the latest failed run ID
-RUN_ID=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+RUN_ID=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | \
     curl -s -K- "https://api.github.com/repos/$REPO/actions/workflows/$WORKFLOW/runs?status=failure&per_page=1" \
     | jq -r '.workflow_runs[0].id')
 
@@ -55,7 +55,7 @@ fi
 echo "Found failed run ID: $RUN_ID. Fetching jobs..."
 
 # Get jobs data for the failed run once
-JOBS_DATA=$(printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+JOBS_DATA=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | \
     curl -s -K- "https://api.github.com/repos/$REPO/actions/runs/$RUN_ID/jobs")
 
 # Extract IDs and names of failed jobs
@@ -70,7 +70,7 @@ echo "$FAILED_JOBS" | while IFS='|' read -r JOB_ID JOB_NAME; do
     echo "---------------------------------------------------------"
 
     # Fetch logs for the job
-    printf "header = \"Authorization: token %s\"\n" "$GITHUB_TOKEN" | \
+    printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | \
         curl -s -K- -L "https://api.github.com/repos/$REPO/actions/jobs/$JOB_ID/logs"
 
     echo ""


### PR DESCRIPTION
🛡️ Sentinel: Fix potential shell injection and standardize GitHub auth

This PR implements two security improvements following the Sentinel philosophy:

1. **Defense-in-Depth against Shell Injection**: In `github_scripts/gh_pr_size_checker.sh`, the calculation of total changes (additions + deletions) and the subsequent size categorization (XS-XL) were moved into a single `jq` pipeline. This prevents potential shell arithmetic injection if the GitHub API (or a malicious proxy/mock) were to return crafted strings instead of numbers.

2. **Standardization of GitHub Authentication**: All scripts utilizing the GitHub API via `curl -K-` have been updated to use the `Authorization: Bearer` header format. While GitHub still supports the `token` keyword, `Bearer` is the current standard for Personal Access Tokens.

**Affected Files:**
- `github_scripts/gh_list_pull_requests.sh`
- `github_scripts/gh_list_collaborators.sh`
- `github_scripts/gh_create_release.sh`
- `github_scripts/gh_pr_size_checker.sh`
- `github_scripts/gh_workflow_failure_logs.sh`
- `.jules/sentinel.md` (Journal update)

**Verification:**
- Ran `./tests/verify_curl_scripts.sh`: Confirmed that `Bearer` tokens are correctly handled and scripts function as expected with the mocked API.
- Ran `./tests/verify_all.sh`: Ensured no regressions in general script logic.
- Manual verification of `gh_pr_size_checker.sh` arithmetic logic with edge case JSON payloads.

---
*PR created automatically by Jules for task [9435763771399772136](https://jules.google.com/task/9435763771399772136) started by @kobi070*