### PR TITLE
🛡️ Sentinel: [HIGH] Fix shell arithmetic injection in ArgoCD and K8s scripts

### DIFF
--- a/argocd_scripts/argocd_app_sync.sh
+++ b/argocd_scripts/argocd_app_sync.sh
@@ -34,6 +34,12 @@ fi
 APP_NAME=$1
 TIMEOUT=${2:-300}
 
+# Security check: Ensure TIMEOUT is a numeric integer to prevent shell arithmetic injection
+if [[ ! "$TIMEOUT" =~ ^[0-9]+$ ]]; then
+    echo "Error: TIMEOUT must be a positive numeric integer."
+    exit 1
+fi
+
 echo "Syncing ArgoCD application: $APP_NAME..."
 
 # Trigger sync

--- a/k8s_scripts/k8s_pod_restart_detector.sh
+++ b/k8s_scripts/k8s_pod_restart_detector.sh
@@ -38,6 +38,12 @@ fi
 
 THRESHOLD=${2:-1}
 
+# Security check: Ensure THRESHOLD is a numeric integer to prevent shell arithmetic injection
+if [[ ! "$THRESHOLD" =~ ^[0-9]+$ ]]; then
+    echo "Error: THRESHOLD must be a positive numeric integer."
+    exit 1
+fi
+
 echo "Scanning for pods with at least $THRESHOLD restarts..."
 
 # Get pod restart counts using kubectl and jq


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Shell arithmetic injection via unvalidated numeric inputs (`TIMEOUT` and `THRESHOLD`).
🎯 Impact: An attacker could execute arbitrary commands if they can control these input variables, as Bash evaluates arithmetic expressions which can include command substitution.
🔧 Fix: Added strict regex validation `[[ "$VAR" =~ ^[0-9]+$ ]]` to ensure the inputs are numeric integers before use.
✅ Verification: Manually verified with malicious payloads (`1; id`) which were correctly rejected. Ran `tests/verify_all.sh` to ensure no regressions.

---
*PR created automatically by Jules for task [4573194636895566915](https://jules.google.com/task/4573194636895566915) started by @kobi070*