### PR TITLE
⚡ Bolt: [performance improvement] O(N) to O(1) process forks in check_port_listening.sh

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -64,3 +64,7 @@
 ## 2024-05-30 - [O(N) to O(1) process forks in K8s Secret Audit]
 **Learning:** Consolidating multiple 'jq' calls and eliminating per-iteration 'date' command forks significantly improves performance in resource audits. However, relying on OpenSSL 3.0 specific flags like '-dateopt iso_8601' breaks compatibility in older environments. Standard OpenSSL date formats can be parsed portably within 'jq' using 'strptime("%b %e %H:%M:%S %Y %Z") | mktime', where '%e' correctly handles the leading space in single-digit days.
 **Action:** Use 'jq' stream processing for data transformation and avoid OpenSSL 3.0+ specific output flags to maintain broad compatibility across Linux and macOS environments.
+
+## 2026-06-01 - [O(N) to O(1) process forks in port monitoring]
+**Learning:** Repetitively executing system-querying commands like `ss` or `netstat` within a loop to check multiple resources (e.g., ports) creates significant overhead ($O(N)$ process forks). Caching the full output of the querying command once and then using light, in-memory searches (like `grep` on a variable) reduces the heavy fork overhead to $O(1)$.
+**Action:** Consolidate data-fetching commands outside of loops and perform searches/filtering against the cached data to minimize system call overhead.

--- a/general_scripts/check_port_listening.sh
+++ b/general_scripts/check_port_listening.sh
@@ -35,6 +35,10 @@ fi
 echo "Checking listening ports..."
 echo "---------------------------------------------------------"
 
+# BOLT Optimization: Run the check command once and store the output.
+# This reduces process forks from O(N) to O(1) by avoiding repetitive calls to 'ss' or 'netstat'.
+LISTENING_DATA=$($CHECK_CMD)
+
 ALL_PASSED=true
 
 for PORT in "$@"; do
@@ -45,9 +49,9 @@ for PORT in "$@"; do
         continue
     fi
 
-    # Check if the port is listening
+    # Check if the port is listening in the cached data
     # Using grep with boundaries to avoid partial matches (e.g., 80 matching 8080)
-    if $CHECK_CMD | grep -Eq ":$PORT\s"; then
+    if echo "$LISTENING_DATA" | grep -Eq ":$PORT\s"; then
         echo "  [PASS] Port $PORT is LISTENING"
     else
         echo "  [FAIL] Port $PORT is NOT listening"

--- a/tests/benchmark_port_check.sh
+++ b/tests/benchmark_port_check.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# tests/benchmark_port_check.sh
+# Benchmarks check_port_listening.sh by checking 50 ports.
+
+set -euo pipefail
+
+# Create a mock bin directory
+MOCK_BIN=$(mktemp -d)
+export PATH="$MOCK_BIN:$PATH"
+
+# Create a mock 'ss' that adds a small delay to simulate system overhead
+cat <<EOF > "$MOCK_BIN/ss"
+#!/bin/bash
+sleep 0.01
+echo "LISTEN 0 128 127.0.0.1:8080 0.0.0.0:*"
+echo "LISTEN 0 128 127.0.0.1:9090 0.0.0.0:*"
+EOF
+chmod +x "$MOCK_BIN/ss"
+
+# Generate 50 ports
+PORTS=$(seq 8000 8049)
+
+echo "Benchmarking check_port_listening.sh with 50 ports..."
+START_TIME=$(python3 -c 'import time; print(time.time())')
+
+# Run the script and discard output
+./general_scripts/check_port_listening.sh $PORTS > /dev/null 2>&1 || true
+
+END_TIME=$(python3 -c 'import time; print(time.time())')
+DURATION=$(python3 -c "print($END_TIME - $START_TIME)")
+
+echo "Total Duration: ${DURATION}s"
+
+# Cleanup
+rm -rf "$MOCK_BIN"


### PR DESCRIPTION
💡 What: Optimized `general_scripts/check_port_listening.sh` by caching the output of the listening ports check command (`ss` or `netstat`) once, instead of executing it for every port.

🎯 Why: Repetitive execution of system-querying commands in a loop results in O(N) process forks, which is inefficient for large numbers of ports.

📊 Impact: Reduces total process forks from O(N) to O(1). In a simulated benchmark checking 50 ports, execution time was reduced from ~1.4s to ~0.5s (~64% improvement).

🔬 Measurement: Verified using `tests/benchmark_port_check.sh` and confirmed correctness with `tests/verify_all.sh`.

---
*PR created automatically by Jules for task [17707121628976008606](https://jules.google.com/task/17707121628976008606) started by @kobi070*