### PR TITLE
🛡️ Sentinel: [HIGH] Fix PAT exposure in process list for Azure DevOps config

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@
 **Vulnerability:** Using `$(variable)` instead of `${variable}` in `echo` or other commands causes Bash to attempt to execute the value of the variable as a command.
 **Learning:** This is a common typo that results in an unintended subshell. If the variable's value (e.g., a version string parsed from a file) can be influenced by an untrusted source, it leads to arbitrary command execution.
 **Prevention:** Strictly use `${variable}` or `$variable` for variable expansion. Avoid the `$(...)` syntax unless command substitution is explicitly intended. Regularly audit scripts for this pattern, especially in log/echo statements.
+
+## 2026-06-01 - PAT Exposure in Process List for Azure DevOps Config
+**Vulnerability:** Accepting Personal Access Tokens (PAT) as positional command-line arguments in `az_devops_config.sh` exposes them in the system's process list and shell history.
+**Learning:** Positional arguments for secrets are insecure in shared environments. Even if an environment variable fallback is provided, allowing the positional argument encourages insecure usage.
+**Prevention:** Strictly enforce the use of environment variables for all secrets. Remove fallback to positional arguments for sensitive information to align with "Secure by Default" principles.

--- a/az_scripts/az_devops_config.sh
+++ b/az_scripts/az_devops_config.sh
@@ -2,17 +2,17 @@
 
 # Script to configure Azure DevOps CLI with Organization URL and Personal Access Token (PAT).
 # Useful for initializing Azure DevOps CLI in CI/CD environments.
-# Usage: ./az_devops_config.sh <org_url> [pat]
-# Example: ./az_devops_config.sh https://dev.azure.com/my-org/ my-long-pat-token
-# Note: Recommends using AZ_DEVOPS_PAT environment variable for the PAT to avoid exposure.
+# Usage: ./az_devops_config.sh <org_url>
+# Example: ./az_devops_config.sh https://dev.azure.com/my-org/
+# Note: Requires AZ_DEVOPS_PAT environment variable for the PAT to avoid exposure.
 
 set -euo pipefail
 
 # Help function
 usage() {
-    echo "Usage: $0 <org_url> [pat]"
+    echo "Usage: $0 <org_url>"
     echo "  org_url: The Azure DevOps Organization URL"
-    echo "  pat: (optional) Personal Access Token. Can also be set via AZ_DEVOPS_PAT env var."
+    echo "  Note: Requires AZ_DEVOPS_PAT environment variable for authentication."
     exit 1
 }
 
@@ -28,16 +28,19 @@ if ! command -v az &> /dev/null; then
 fi
 
 # Input validation
-if [ "$#" -lt 1 ]; then
+if [ "$#" -ne 1 ]; then
     usage
 fi
 
 ORG_URL=$1
-# Prefer argument, fallback to environment variable
-PAT=${2:-${AZ_DEVOPS_PAT:-}}
+
+# Security Pattern: Prioritize environment variables for secrets to prevent exposure in process lists.
+# Fallback to positional arguments is intentionally removed to align with Sentinel standards.
+PAT=${AZ_DEVOPS_PAT:-}
 
 if [ -z "$PAT" ]; then
-    echo "Error: Personal Access Token (PAT) must be provided as the second argument or via AZ_DEVOPS_PAT environment variable."
+    echo "Error: AZ_DEVOPS_PAT environment variable is not set."
+    echo "Please set it before running this script for secure authentication."
     exit 1
 fi
 

--- a/tests/verify_all.sh
+++ b/tests/verify_all.sh
@@ -531,7 +531,53 @@ else
     exit 1
 fi
 
-# --- 23. Mock for k8s_secret_expiry_check.sh ---
+# --- 23. Mock for az_devops_config.sh ---
+cat <<'EOF' > "$MOCK_BIN/az"
+#!/bin/bash
+if [[ "$*" == *"extension show --name azure-devops"* ]]; then
+  exit 0
+elif [[ "$*" == *"devops login --organization"* ]]; then
+  # Read from stdin to see if it contains the PAT
+  PAT_CONTENT=$(cat -)
+  if [[ "$PAT_CONTENT" == "mock_pat" ]]; then
+    echo "Logged in successfully"
+    exit 0
+  else
+    echo "Error: PAT not found in stdin" >&2
+    exit 1
+  fi
+elif [[ "$*" == *"devops configure --defaults organization="* ]]; then
+  exit 0
+fi
+EOF
+chmod +x "$MOCK_BIN/az"
+
+echo "Testing az_devops_config.sh..."
+# Test case 1: Missing environment variable
+if AZ_DEVOPS_PAT="" ./az_scripts/az_devops_config.sh https://dev.azure.com/org 2>&1 | grep -q "Error: AZ_DEVOPS_PAT environment variable is not set"; then
+    echo "  ✔ Corrected handled missing environment variable"
+else
+    echo "  ✖ Failed to handle missing environment variable"
+    exit 1
+fi
+
+# Test case 2: Successful configuration
+if AZ_DEVOPS_PAT="mock_pat" ./az_scripts/az_devops_config.sh https://dev.azure.com/org 2>&1 | grep -q "Success: Azure DevOps CLI configured"; then
+    echo "  ✔ Successfully configured az devops"
+else
+    echo "  ✖ Failed to configure az devops"
+    exit 1
+fi
+
+# Test case 3: Rejection of positional argument
+if AZ_DEVOPS_PAT="mock_pat" ./az_scripts/az_devops_config.sh https://dev.azure.com/org insecure_pat 2>&1 | grep -q "Usage:"; then
+    echo "  ✔ Rejected insecure positional argument"
+else
+    echo "  ✖ Failed to reject insecure positional argument"
+    exit 1
+fi
+
+# --- 24. Mock for k8s_secret_expiry_check.sh ---
 cat <<'EOF' > "$MOCK_BIN/kubectl"
 #!/bin/bash
 if [[ "$*" == *"get secrets"* ]]; then


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `az_devops_config.sh` script accepted a Personal Access Token (PAT) as a positional command-line argument.
🎯 Impact: Passing secrets as arguments exposes them in the system's process list (e.g., `ps aux`) and shell history, potentially allowing other users or malicious processes on the same host to steal the token.
🔧 Fix: Removed the positional argument for PAT and enforced the use of the `AZ_DEVOPS_PAT` environment variable. Updated usage instructions and input validation.
✅ Verification: Added a new test case to `tests/verify_all.sh` that mocks the `az` CLI and validates that the script correctly requires the environment variable and rejects positional arguments.

---
*PR created automatically by Jules for task [4550210833259662320](https://jules.google.com/task/4550210833259662320) started by @kobi070*