### PR TITLE
⚡ Bolt: [performance improvement] Consolidate kubectl logs calls

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -64,3 +64,7 @@
 ## 2024-05-30 - [O(N) to O(1) process forks in K8s Secret Audit]
 **Learning:** Consolidating multiple 'jq' calls and eliminating per-iteration 'date' command forks significantly improves performance in resource audits. However, relying on OpenSSL 3.0 specific flags like '-dateopt iso_8601' breaks compatibility in older environments. Standard OpenSSL date formats can be parsed portably within 'jq' using 'strptime("%b %e %H:%M:%S %Y %Z") | mktime', where '%e' correctly handles the leading space in single-digit days.
 **Action:** Use 'jq' stream processing for data transformation and avoid OpenSSL 3.0+ specific output flags to maintain broad compatibility across Linux and macOS environments.
+
+## 2024-06-05 - [O(N) to O(1) kubectl logs]
+**Learning:** Fetching logs for multiple pods matching a label by first listing pods and then iterating through them creates a performance bottleneck ($O(N)$ process forks). `kubectl logs` natively supports label selectors (`-l`) and can prefix log lines with the pod name (`--prefix=true`), allowing all logs to be retrieved in a single process fork.
+**Action:** Use `kubectl logs -l <selector> --prefix=true` instead of shell loops when fetching logs for multiple pods by label.

--- a/k8s_scripts/k8s_pod_logs_by_label.sh
+++ b/k8s_scripts/k8s_pod_logs_by_label.sh
@@ -43,18 +43,10 @@ fi
 
 echo "Fetching logs for pods with label '$LABEL_SELECTOR' in namespace '$NAMESPACE'..."
 
-# Get all pod names matching the label
-PODS=$(kubectl get pods -n "$NAMESPACE" -l "$LABEL_SELECTOR" -o jsonpath='{.items[*].metadata.name}')
+# BOLT Optimization: Use a single kubectl logs call with -l and --prefix=true.
+# This reduces the process forks from O(N) to O(1) by avoiding the need to
+# first fetch all pod names and then iterate through them sequentially.
+# The --prefix=true flag ensures that each log line is prefixed with the pod name.
+kubectl logs -n "$NAMESPACE" -l "$LABEL_SELECTOR" --prefix=true $TAIL_ARG || echo "No pods found or failed to fetch logs for '$LABEL_SELECTOR'"
 
-if [ -z "$PODS" ]; then
-    echo "No pods found matching label '$LABEL_SELECTOR' in namespace '$NAMESPACE'."
-    exit 0
-fi
-
-for POD in $PODS; do
-    echo "================================================================================"
-    echo "Logs for pod: $POD"
-    echo "================================================================================"
-    kubectl logs -n "$NAMESPACE" "$POD" $TAIL_ARG || echo "Failed to fetch logs for $POD"
-    echo -e "\n"
-done
+echo -e "\nDone."


### PR DESCRIPTION
💡 What: Optimized `k8s_scripts/k8s_pod_logs_by_label.sh` to use a single `kubectl logs` call with label selector and prefix.
🎯 Why: The previous implementation used a shell loop, resulting in $O(N)$ process forks (one per pod). This consolidates it into a single $O(1)$ call.
📊 Impact: Reduces process forks from $1+N$ to 1 for $N$ pods, significantly reducing latency and resource overhead in large clusters.
🔬 Measurement: Verified using a mock `kubectl` that logs calls, confirming only one invocation for multiple matching pods.

---
*PR created automatically by Jules for task [4311574869846052398](https://jules.google.com/task/4311574869846052398) started by @kobi070*