### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix Command Injection via Indirect Expansion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@
 **Vulnerability:** Using `$(variable)` instead of `${variable}` in `echo` or other commands causes Bash to attempt to execute the value of the variable as a command.
 **Learning:** This is a common typo that results in an unintended subshell. If the variable's value (e.g., a version string parsed from a file) can be influenced by an untrusted source, it leads to arbitrary command execution.
 **Prevention:** Strictly use `${variable}` or `$variable` for variable expansion. Avoid the `$(...)` syntax unless command substitution is explicitly intended. Regularly audit scripts for this pattern, especially in log/echo statements.
+
+## 2026-06-01 - Command Injection via Bash Indirect Expansion
+**Vulnerability:** Using Bash indirect expansion `${!VAR_NAME}` with untrusted input in `VAR_NAME` allows arbitrary command execution. Bash evaluates array indices within the indirect expansion context.
+**Learning:** Payloads like `a[$(touch VULNERABLE)]` passed as a variable name will trigger command execution when `${!VAR_NAME}` is evaluated, even if the variable name itself is quoted. This is a subtle but critical injection vector in scripts that dynamically validate environment variables.
+**Prevention:** Always strictly validate that any variable name used for indirect expansion is a valid shell identifier using a regex like `[[ "$VAR_NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]` before expansion.

--- a/general_scripts/validate_env_vars.sh
+++ b/general_scripts/validate_env_vars.sh
@@ -29,6 +29,15 @@ MISSING_VARS=()
 echo "Validating environment variables..."
 
 for VAR_NAME in "$@"; do
+    # Security check: Validate that the variable name is a valid shell identifier.
+    # This prevents command injection via Bash indirect expansion ${!VAR_NAME}.
+    # Indirect expansion evaluates array indices, allowing payloads like 'a[$(touch VULNERABLE)]'.
+    if [[ ! "$VAR_NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "  [FAIL] $VAR_NAME is not a valid environment variable name."
+        MISSING_VARS+=("$VAR_NAME")
+        continue
+    fi
+
     if [ -z "${!VAR_NAME:-}" ]; then
         echo "  [FAIL] $VAR_NAME is NOT set or is empty."
         MISSING_VARS+=("$VAR_NAME")

--- a/jfrog_scripts/pull_generic.sh
+++ b/jfrog_scripts/pull_generic.sh
@@ -11,6 +11,13 @@ fi
 
 # Validate environment variables
 for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  # Security check: Validate that the variable name is a valid shell identifier.
+  # This prevents command injection via Bash indirect expansion ${!var}.
+  if [[ ! "$var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "Error: Invalid environment variable name: $var"
+    exit 1
+  fi
+
   if [ -z "${!var:-}" ]; then
     echo "Error: Environment variable $var is not set."
     exit 1

--- a/jfrog_scripts/upload_generic.sh
+++ b/jfrog_scripts/upload_generic.sh
@@ -11,6 +11,13 @@ fi
 
 # Validate environment variables
 for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  # Security check: Validate that the variable name is a valid shell identifier.
+  # This prevents command injection via Bash indirect expansion ${!var}.
+  if [[ ! "$var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "Error: Invalid environment variable name: $var"
+    exit 1
+  fi
+
   if [ -z "${!var:-}" ]; then
     echo "Error: Environment variable $var is not set."
     exit 1


### PR DESCRIPTION
🚨 Severity: CRITICAL/HIGH
💡 Vulnerability: Command injection via Bash indirect expansion `${!VAR_NAME}`.
🎯 Impact: An attacker could execute arbitrary commands by passing a malicious string (e.g., `a[$(command)]`) as a variable name to scripts that use indirect expansion.
🔧 Fix: Implemented regex-based whitelist validation (`[[ "$VAR" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]`) for all variable names before they are used in indirect expansion.
✅ Verification: Verified using a reproduction script that attempted to inject a command via a variable name. The command was successfully blocked and the script exited with an error as expected. Legitimate variable names still function correctly.

---
*PR created automatically by Jules for task [17909946139442040259](https://jules.google.com/task/17909946139442040259) started by @kobi070*