### PR TITLE
🛡️ Sentinel: [HIGH] Fix command injection via indirect expansion

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@
 **Vulnerability:** Using `$(variable)` instead of `${variable}` in `echo` or other commands causes Bash to attempt to execute the value of the variable as a command.
 **Learning:** This is a common typo that results in an unintended subshell. If the variable's value (e.g., a version string parsed from a file) can be influenced by an untrusted source, it leads to arbitrary command execution.
 **Prevention:** Strictly use `${variable}` or `$variable` for variable expansion. Avoid the `$(...)` syntax unless command substitution is explicitly intended. Regularly audit scripts for this pattern, especially in log/echo statements.
+
+## 2026-06-21 - Command Injection via Bash Indirect Expansion
+**Vulnerability:** User-supplied input used as the variable name in Bash indirect expansion (${!VAR}) allows arbitrary command execution if the input contains malicious payloads like 'a[$(command)]'.
+**Learning:** Bash evaluates array indices within indirect expansion. If an attacker controls the variable name being expanded, they can inject command substitutions that Bash will execute during the expansion process.
+**Prevention:** Strictly validate that any variable name used in indirect expansion is a valid shell identifier (e.g., matching the regex ^[a-zA-Z_][a-zA-Z0-9_]*$) before performing the expansion.

--- a/general_scripts/validate_env_vars.sh
+++ b/general_scripts/validate_env_vars.sh
@@ -29,6 +29,13 @@ MISSING_VARS=()
 echo "Validating environment variables..."
 
 for VAR_NAME in "$@"; do
+    # Security check: Ensure VAR_NAME is a valid shell identifier to prevent command injection via indirect expansion.
+    if [[ ! "$VAR_NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "  [FAIL] $VAR_NAME is NOT a valid environment variable name."
+        MISSING_VARS+=("$VAR_NAME")
+        continue
+    fi
+
     if [ -z "${!VAR_NAME:-}" ]; then
         echo "  [FAIL] $VAR_NAME is NOT set or is empty."
         MISSING_VARS+=("$VAR_NAME")

--- a/jfrog_scripts/pull_generic.sh
+++ b/jfrog_scripts/pull_generic.sh
@@ -11,6 +11,12 @@ fi
 
 # Validate environment variables
 for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  # Security check: Ensure variable name is a valid shell identifier to prevent command injection via indirect expansion.
+  if [[ ! "$var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "Error: Invalid environment variable name $var."
+    exit 1
+  fi
+
   if [ -z "${!var:-}" ]; then
     echo "Error: Environment variable $var is not set."
     exit 1

--- a/jfrog_scripts/upload_generic.sh
+++ b/jfrog_scripts/upload_generic.sh
@@ -11,6 +11,12 @@ fi
 
 # Validate environment variables
 for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  # Security check: Ensure variable name is a valid shell identifier to prevent command injection via indirect expansion.
+  if [[ ! "$var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "Error: Invalid environment variable name $var."
+    exit 1
+  fi
+
   if [ -z "${!var:-}" ]; then
     echo "Error: Environment variable $var is not set."
     exit 1

--- a/tests/repro_injection.sh
+++ b/tests/repro_injection.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# repro_injection.sh - Reproduce command injection via indirect expansion
+
+SENTINEL_FILE="pwned_validate_repro"
+rm -f "$SENTINEL_FILE"
+
+echo "Attempting to exploit indirect expansion in validate_env_vars.sh..."
+# The payload is in the variable name itself
+./general_scripts/validate_env_vars.sh "foo[\$(touch $SENTINEL_FILE)]" > /dev/null 2>&1 || true
+
+if [ -f "$SENTINEL_FILE" ]; then
+    echo "❌ VULNERABILITY REPRODUCED: $SENTINEL_FILE was created!"
+    rm "$SENTINEL_FILE"
+    exit 1
+else
+    echo "✅ Vulnerability not triggered."
+    exit 0
+fi


### PR DESCRIPTION
This PR fixes a high-severity command injection vulnerability in several utility scripts.

The vulnerability stems from the use of Bash indirect expansion `${!VAR_NAME}` where `VAR_NAME` is derived from user-supplied arguments. An attacker could pass a malicious string like `foo[$(touch pwned)]`, which Bash evaluates as an array index during indirect expansion, triggering command substitution and arbitrary code execution.

Changes:
- Added strict regex validation `[[ "$VAR" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]` in `general_scripts/validate_env_vars.sh`, `jfrog_scripts/pull_generic.sh`, and `jfrog_scripts/upload_generic.sh` to ensure only valid shell identifiers are used in indirect expansion.
- Added a reproduction test script `tests/repro_injection.sh` to verify the fix and prevent regressions.
- Recorded the vulnerability and fix in `.jules/sentinel.md`.

All tests in `tests/verify_all.sh` pass.

---
*PR created automatically by Jules for task [14226582747913742045](https://jules.google.com/task/14226582747913742045) started by @kobi070*