### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in validate_env_vars.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@
 **Vulnerability:** Using `$(variable)` instead of `${variable}` in `echo` or other commands causes Bash to attempt to execute the value of the variable as a command.
 **Learning:** This is a common typo that results in an unintended subshell. If the variable's value (e.g., a version string parsed from a file) can be influenced by an untrusted source, it leads to arbitrary command execution.
 **Prevention:** Strictly use `${variable}` or `$variable` for variable expansion. Avoid the `$(...)` syntax unless command substitution is explicitly intended. Regularly audit scripts for this pattern, especially in log/echo statements.
+
+## 2026-06-23 - Command Injection via Bash Indirect Expansion
+**Vulnerability:** Bash's indirect expansion `${!VAR_NAME}` evaluates the content of `VAR_NAME`. If `VAR_NAME` contains an array index like `foo[$(command)]`, Bash executes the command during expansion.
+**Learning:** This vulnerability is particularly dangerous in scripts that validate environment variables by name (e.g., `validate_env_vars.sh`), as it allows an attacker who can control the arguments to execute arbitrary code.
+**Prevention:** Always validate that the variable name passed to an indirect expansion is a valid shell identifier (e.g., matching `^[a-zA-Z_][a-zA-Z0-9_]*$`) before the expansion occurs.

--- a/general_scripts/validate_env_vars.sh
+++ b/general_scripts/validate_env_vars.sh
@@ -29,6 +29,13 @@ MISSING_VARS=()
 echo "Validating environment variables..."
 
 for VAR_NAME in "$@"; do
+    # Security check: Ensure VAR_NAME is a valid shell identifier to prevent command injection via indirect expansion
+    if [[ ! "$VAR_NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "  [FAIL] $VAR_NAME is NOT a valid environment variable name."
+        MISSING_VARS+=("$VAR_NAME")
+        continue
+    fi
+
     if [ -z "${!VAR_NAME:-}" ]; then
         echo "  [FAIL] $VAR_NAME is NOT set or is empty."
         MISSING_VARS+=("$VAR_NAME")

--- a/jfrog_scripts/pull_generic.sh
+++ b/jfrog_scripts/pull_generic.sh
@@ -11,6 +11,12 @@ fi
 
 # Validate environment variables
 for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  # Security check: Ensure var is a valid shell identifier
+  if [[ ! "$var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "Error: Invalid environment variable name $var."
+    exit 1
+  fi
+
   if [ -z "${!var:-}" ]; then
     echo "Error: Environment variable $var is not set."
     exit 1

--- a/jfrog_scripts/upload_generic.sh
+++ b/jfrog_scripts/upload_generic.sh
@@ -11,6 +11,12 @@ fi
 
 # Validate environment variables
 for var in JFROG_API_KEY JFROG_URL JFROG_REPO; do
+  # Security check: Ensure var is a valid shell identifier
+  if [[ ! "$var" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+    echo "Error: Invalid environment variable name $var."
+    exit 1
+  fi
+
   if [ -z "${!var:-}" ]; then
     echo "Error: Environment variable $var is not set."
     exit 1


### PR DESCRIPTION
### 🛡️ Sentinel Security Fix

**🚨 Severity:** CRITICAL
**💡 Vulnerability:** Command injection via Bash indirect expansion `${!VAR_NAME}`.
**🎯 Impact:** An attacker who can control the arguments passed to `validate_env_vars.sh` (or other scripts using indirect expansion on user-supplied data) can execute arbitrary commands on the system. This is because Bash evaluates the content of the variable name being expanded; if it contains an array index with a subshell (e.g., `foo[$(whoami)]`), the subshell is executed.
**🔧 Fix:** Implemented a strict regex-based whitelist validation (`^[a-zA-Z_][a-zA-Z0-9_]*$`) for environment variable names before any indirect expansion occurs. This ensures that only valid shell identifiers are processed, blocking malicious payloads.
**✅ Verification:** 
1. Created a reproduction script that passed a malicious payload to `validate_env_vars.sh` and confirmed command execution.
2. Verified that after the fix, the same payload is rejected as an invalid variable name and no command execution occurs.
3. Verified that standard variable names (e.g., `DOCKER_USERNAME`) are still correctly validated.
4. Ran the full verification suite (`tests/verify_all.sh` and `tests/verify_curl_scripts.sh`) to ensure zero regressions in existing functionality.

Impacted files:
- `general_scripts/validate_env_vars.sh`
- `jfrog_scripts/pull_generic.sh`
- `jfrog_scripts/upload_generic.sh`
- `.jules/sentinel.md` (Security journal updated)

---
*PR created automatically by Jules for task [14751705941673611841](https://jules.google.com/task/14751705941673611841) started by @kobi070*