### PR TITLE
🛡️ Sentinel: [HIGH] Fix argument injection in multiple scripts

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@
 **Vulnerability:** Using `$(variable)` instead of `${variable}` in `echo` or other commands causes Bash to attempt to execute the value of the variable as a command.
 **Learning:** This is a common typo that results in an unintended subshell. If the variable's value (e.g., a version string parsed from a file) can be influenced by an untrusted source, it leads to arbitrary command execution.
 **Prevention:** Strictly use `${variable}` or `$variable` for variable expansion. Avoid the `$(...)` syntax unless command substitution is explicitly intended. Regularly audit scripts for this pattern, especially in log/echo statements.
+
+## 2026-05-31 - Argument Injection in CLI Tools
+**Vulnerability:** User-supplied variables passed directly to CLI tools like `curl` or `grep` (e.g., `curl $URL`) can be interpreted as command-line options if they start with a hyphen.
+**Learning:** This allows an attacker to inject arbitrary flags, potentially changing the behavior of the command (e.g., using `-v` to leak headers, or `-o` to overwrite files in `curl`, or using `-f` to read files in `grep`).
+**Prevention:** Always use the `--` separator before positional arguments or variables that could contain untrusted input to signal the end of command options.

--- a/general_scripts/check_url_content.sh
+++ b/general_scripts/check_url_content.sh
@@ -82,12 +82,12 @@ while [ $SECONDS -lt $end_time ]; do
     # -i: include headers (to get the status code)
     # We'll use -w to get the status code separately for easier checking
 
-    response=$(curl -sL -w "%{http_code}" "$URL" || true)
+    response=$(curl -sL -w "%{http_code}" -- "$URL" || true)
     http_code="${response: -3}"
     body="${response%???}"
 
     if [[ "$http_code" == "200" ]]; then
-        if echo "$body" | grep -q "$SEARCH_STRING"; then
+        if echo "$body" | grep -q -- "$SEARCH_STRING"; then
             echo "Success: URL is reachable and contains the search string."
             exit 0
         else

--- a/general_scripts/wait_for_url.sh
+++ b/general_scripts/wait_for_url.sh
@@ -42,7 +42,7 @@ echo "Waiting for URL $URL to return 200 OK (timeout: ${TIMEOUT}s, interval: ${I
 SECONDS=0
 
 while [ "$SECONDS" -lt "$TIMEOUT" ]; do
-    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$URL" || true)
+    HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -- "$URL" || true)
 
     if [ "$HTTP_CODE" == "200" ]; then
         echo "Success: URL $URL is reachable and returned 200 OK."

--- a/github_scripts/gh_list_pull_requests.sh
+++ b/github_scripts/gh_list_pull_requests.sh
@@ -48,9 +48,9 @@ API_URL="https://api.github.com/repos/$REPO/pulls?state=$STATE"
 
 # Use curl config file via stdin to prevent leaking GITHUB_TOKEN in process lists (ps)
 if [ -n "${GITHUB_TOKEN:-}" ]; then
-    PRS=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | curl -s -K- -H "Accept: application/vnd.github.v3+json" "$API_URL")
+    PRS=$(printf "header = \"Authorization: Bearer %s\"\n" "$GITHUB_TOKEN" | curl -s -K- -H "Accept: application/vnd.github.v3+json" -- "$API_URL")
 else
-    PRS=$(curl -s -H "Accept: application/vnd.github.v3+json" "$API_URL")
+    PRS=$(curl -s -H "Accept: application/vnd.github.v3+json" -- "$API_URL")
 fi
 
 # Check for errors in response


### PR DESCRIPTION
🚨 **Severity:** HIGH

💡 **Vulnerability:**
User-supplied variables passed directly to CLI tools like `curl` and `grep` (e.g., `curl $URL` or `grep "$STRING"`) were missing the `--` separator. This allowed an attacker to inject arbitrary command-line options by providing an input that starts with a hyphen (e.g., `-v` for `curl` or `--help` for `grep`).

🎯 **Impact:**
An attacker could potentially manipulate the behavior of these scripts. For example, injecting `-v` into `curl` could expose sensitive headers in verbose logs, or injecting `-o` could be used to overwrite local files.

🔧 **Fix:**
Added the `--` separator before user-supplied variables in the following scripts to signal the end of command options:
- `general_scripts/check_url_content.sh`
- `general_scripts/wait_for_url.sh`
- `github_scripts/gh_list_pull_requests.sh`

✅ **Verification:**
1.  Created a reproduction script that passed `--help` to `grep` and `-v` to `curl` through the script arguments.
2.  Verified that before the fix, the commands interpreted these as options (e.g., `grep` showed its help page).
3.  Verified that after the fix, the commands treated the inputs as literal data.
4.  Ran `tests/verify_curl_scripts.sh` and `tests/verify_all.sh` to ensure no regressions.

---
*PR created automatically by Jules for task [672329937185103947](https://jules.google.com/task/672329937185103947) started by @kobi070*