### PR TITLE
🛡️ Sentinel: [security improvement] Harden gh_pr_stats.sh against argument injection

### DIFF
--- a/github_scripts/gh_pr_stats.sh
+++ b/github_scripts/gh_pr_stats.sh
@@ -29,18 +29,25 @@ for tool in gh jq; do
     fi
 done
 
-REPO_ARG=""
+ARGS=()
 if [ "$#" -ge 1 ]; then
-    REPO_ARG="-R $1"
+    ARGS+=("-R" "$1")
 fi
 
 LIMIT=${2:-30}
+
+# Security Pattern: validate numeric input to prevent arithmetic injection
+if [[ ! "$LIMIT" =~ ^[0-9]+$ ]]; then
+    echo "Error: limit must be a positive integer."
+    exit 1
+fi
 
 echo "Fetching statistics for the last $LIMIT merged PRs..."
 
 # Fetch merged PRs with their creation and merge timestamps
 # Bolt optimization: process data in a single jq pipeline
-PR_DATA=$(gh pr list $REPO_ARG --state merged --limit "$LIMIT" --json createdAt,mergedAt,title,number)
+# Security Pattern: Use array for arguments to prevent injection
+PR_DATA=$(gh pr list "${ARGS[@]}" --state merged --limit "$LIMIT" --json createdAt,mergedAt,title,number)
 
 if [ "$(echo "$PR_DATA" | jq '. | length')" -eq 0 ]; then
     echo "No merged Pull Requests found."


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: Potential argument injection in `gh_pr_stats.sh` due to unquoted repository name handled as a string and missing numeric validation on the `LIMIT` parameter.
🎯 **Impact**: A malicious repository name (e.g., `owner/repo --verbose`) could inject unexpected flags into the `gh pr list` command. Missing numeric validation on `LIMIT` could lead to shell arithmetic injection or unexpected CLI behavior.
🔧 **Fix**: Refactored the script to use a Bash array for optional `gh` arguments and added a regex-based numeric validation check for the `LIMIT` input.
✅ **Verification**: 
1. Verified with a reproduction script that `owner/repo --verbose` is now correctly passed as a single argument to `gh`.
2. Confirmed that non-numeric `LIMIT` values are rejected.
3. Ran `tests/verify_all.sh` and `tests/verify_curl_scripts.sh` to ensure no regressions.

---
*PR created automatically by Jules for task [11382768683012165992](https://jules.google.com/task/11382768683012165992) started by @kobi070*