### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix command injection in validate_env_vars.sh

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -61,3 +61,8 @@
 **Vulnerability:** Using `$(variable)` instead of `${variable}` in `echo` or other commands causes Bash to attempt to execute the value of the variable as a command.
 **Learning:** This is a common typo that results in an unintended subshell. If the variable's value (e.g., a version string parsed from a file) can be influenced by an untrusted source, it leads to arbitrary command execution.
 **Prevention:** Strictly use `${variable}` or `$variable` for variable expansion. Avoid the `$(...)` syntax unless command substitution is explicitly intended. Regularly audit scripts for this pattern, especially in log/echo statements.
+
+## 2026-06-27 - Command Injection via Bash Indirect Expansion
+**Vulnerability:** Unvalidated user input used in Bash indirect expansion `${!VAR_NAME}` allows arbitrary command execution.
+**Learning:** Bash evaluates array indices within indirect expansion. If `VAR_NAME` contains a payload like `VAR[$(command)]`, Bash executes the command during the expansion process.
+**Prevention:** Strictly validate that any variable name used for indirect expansion is a valid shell identifier using a regex like `[[ "$VAR" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]`. This prevents the interpretation of special characters and subshells within the expansion.

--- a/general_scripts/validate_env_vars.sh
+++ b/general_scripts/validate_env_vars.sh
@@ -29,6 +29,13 @@ MISSING_VARS=()
 echo "Validating environment variables..."
 
 for VAR_NAME in "$@"; do
+    # Security check: Ensure VAR_NAME is a valid shell identifier to prevent command injection via indirect expansion
+    if [[ ! "$VAR_NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]]; then
+        echo "  [FAIL] $VAR_NAME is NOT a valid environment variable name."
+        MISSING_VARS+=("$VAR_NAME")
+        continue
+    fi
+
     if [ -z "${!VAR_NAME:-}" ]; then
         echo "  [FAIL] $VAR_NAME is NOT set or is empty."
         MISSING_VARS+=("$VAR_NAME")


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Command injection via Bash indirect expansion (`${!VAR_NAME}`).
🎯 Impact: Arbitrary command execution if an attacker can control the input to `validate_env_vars.sh`.
🔧 Fix: Added regex validation (`^[a-zA-Z_][a-zA-Z0-9_]*$`) for environment variable names before expansion.
✅ Verification: Verified that malicious payloads like `VAR[$(touch PWNED)]` are rejected and no longer execute commands. Ran `tests/verify_all.sh` to ensure no regressions.

---
*PR created automatically by Jules for task [3439912320738118005](https://jules.google.com/task/3439912320738118005) started by @kobi070*